### PR TITLE
remove defunct references in bindings.cpp

### DIFF
--- a/src/bindings/PyDP/bindings.cpp
+++ b/src/bindings/PyDP/bindings.cpp
@@ -1,8 +1,5 @@
-#include <string>
-
 #include "pybind11/embed.h"
-#include "differential_privacy/base/status.h"
-#include "differential_privacy/base/statusor.h"
+
 
 using namespace std;
 


### PR DESCRIPTION
cleaning up bindings.cpp, references are now in the appropriate wrapper cpp files