### PR TITLE
Added python version support and testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,48 @@
 pydp.so
+# bazel files
 bazel-bin
 bazel-out
 bazel-PyDP
 bazel-testlogs
 bazel-genfiles
+# don't commit any changes to git-submodules
 third_party/
+# we don't want everyone to have our vscode configurations
 .vscode/
+
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "files.associations": {
-        "string_view": "cpp",
-        "future": "cpp",
-        "*.inc": "cpp",
-        "iosfwd": "cpp"
-    }
-}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,74 @@
+.PHONY: clean clean-test clean-pyc clean-build docs help
+.DEFAULT_GOAL := help
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+	rm -fr .pytest_cache
+
+test: ## run tests quickly with the default Python
+	python setup.py test
+
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage: ## check code coverage quickly with the default Python
+	coverage run --source pydp setup.py test
+	coverage report -m
+	coverage html
+	$(BROWSER) htmlcov/index.html
+
+release: dist ## package and upload a release
+	twine upload dist/*
+
+dist: clean ## builds source and wheel package
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install

--- a/build_PyDP.sh
+++ b/build_PyDP.sh
@@ -7,6 +7,7 @@ while (( "$#" )); do
         FARG=$2
         echo "-f option passed"
         shift 2
+        sed -i '160i\ \ \ \ python_bin_path=repository_ctx.which("python3")\n\ \ \ \ if\ python_bin_path != None:\n\ \ \ \ \ \ \ \ return\ str(python_bin_path)' ./third_party/pybind11_bazel/python_configure.bzl
         sed -i '18s/py/third_party\/pybind11_bazel\/py/' ./third_party/pybind11_bazel/python_configure.bzl
         sed -i '12iPYBIND11_BAZEL_DIR = "//third_party/pybind11_bazel"' ./third_party/pybind11_bazel/python_configure.bzl
         break
@@ -32,4 +33,3 @@ eval set -- "$PARAMS"
 bazel build src/python:bindings_test  --verbose_failures
 rm -f pydp.so
 cp -f ./bazel-bin/src/bindings/pydp.so .
-python test.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,20 @@
+[bumpversion]
+current_version = 0.1.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
+
+[bumpversion:file:grapho/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'
+
+[bdist_wheel]
+universal = 1
+
+
+[aliases]
+# Define setup.py command aliases here
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script."""
+
+from setuptools import setup, find_packages
+import os
+
+
+def read(fname):
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+
+def find_version():
+    version_file = read("tenseal/version.py")
+    version_re = r"__version__ = '(?P<version>.+)'"
+    version = re.match(version_re, version_file).group('version')
+    return version
+
+requirements = [ ]
+
+setup_requirements = [ ]
+
+test_requirements = [ ]
+
+setup(
+    author="Chinmay Shah",
+    author_email='chinmayshah3899@gmail.com',
+    classifiers=[
+        "Programming Language :: C++",
+        'Development Status :: 2 - Pre-Alpha',
+        'Intended Audience :: Developers',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+    description="Wrapper for Google's differential Privacy",
+    install_requires=requirements,
+    license="Apache-2.0",
+    long_description=read("README.md"),
+    long_description_content_type="text/markdown",    
+    include_package_data=True,
+    keywords='pydp',
+    name='pydp',
+    packages=find_packages(include=['pydp']), # need to check this
+    setup_requires=setup_requirements,
+    test_suite='tests',
+    tests_require=test_requirements,
+    url='https://github.com/OpenMined/PyDP',
+    version='0.1.0',
+    zip_safe=False,
+)

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,25 @@
+import pydp as pd
+
+print("Successfully Imported pydp")
+
+# print("Here are the available Status codes from the Base library")
+# x = range(18)
+# for n in x:
+#     print(pd.StatusCode(n))
+
+s = pd.Status(pd.StatusCode(3), "New status object")
+print(s)
+
+url = "http://test.com"
+payload_content = "example payload content"
+
+print("Setting payload: " + payload_content)
+s.set_payload(url, payload_content)
+print("Getting payload: ")
+return_payload = s.get_payload(url)
+print(return_payload)
+print("Erasing payload")
+s.erase_payload(url)
+new_payload=s.get_payload(url)
+print("New payload:")
+print(new_payload)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = py35, py36, py37
+
+[travis]
+python =
+    3.7: py37
+    3.6: py36
+    3.5: py35
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+
+commands = python setup.py test
+


### PR DESCRIPTION
- Added support for python2/ python3 comparison. By default, the system was checking for `python`, which was usually path for python2. Added differentiation for the same in pytbind11_bazel build. 

- Added testing support using Tox. #28 

The check for python3/ python needs to be added to Makefile as well as line#14 in tox.ini