### PR TITLE
Fixed bazel build 

### DIFF
--- a/src/python/BUILD
+++ b/src/python/BUILD
@@ -2,6 +2,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 
 py_binary(
     name = "bindings_test",
-    srcs = ["bindings_test.py"],
+    srcs = ["__init__.py"],
+    main = "__init__.py",
     data = ["//src/bindings:pydp.so"]
 )


### PR DESCRIPTION
After the deletion of bindings_test.py, the Bazel build used to fail. Fixed that by pointing it to empty file, `__init__.py`