### PR TITLE
Add continuous integration via Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches:
+    - master, dev
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.5, 3.6, 3.7]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r ./requirements_dev.txt
+    - name: Set up submodules
+      run: |
+        bash ./ext_source_setup
+    - name: Install pre-requisites
+      run: |
+        sudo apt-get update
+        bash ./prereqs
+        export PATH="$PATH:$HOME/bin"
+    - name: Build pydp lib
+      run: |
+        bash ./build_PyDP.sh -f
+    - name: Run tests
+      run: |
+         python setup.py test 
+    - name: Check test coverage
+      run: |
+         coverage run --source pydp setup.py test
+         coverage report --ignore-errors --fail-under 95 -m

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,6 @@
-pip==18.1
-bumpversion==0.5.3
+setuptools
 wheel==0.32.1
+bumpversion==0.5.3
 watchdog==0.9.0
 tox==3.5.2
 coverage==4.5.1


### PR DESCRIPTION
## Add continuous integration via Github Actions

Add Github Actions workflow to allow Continuous Integration. Relay pip install to workflow.

Fixes #56 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] py35, py36, py37 testenvironments
- [x] [Checks](https://github.com/Benardi/PyDP/runs/491223097) running on fork 

## Checklist:

- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes