### PR TITLE
Remove "first time" flag from build_PyDP.sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         export PATH="$PATH:$HOME/bin"
     - name: Build pydp lib
       run: |
-        bash ./build_PyDP.sh -f
+        bash ./build_PyDP.sh
     - name: Run tests
       run: |
          python setup.py test 

--- a/build_PyDP.sh
+++ b/build_PyDP.sh
@@ -1,17 +1,19 @@
 #!/bin/bash 
 
+EDITION_MARK='# edited by PyDP build script'
+PYTHON_CONFIGURE_BZL_PATH='./third_party/pybind11_bazel/python_configure.bzl'
+
+if ! grep -Fxq "$EDITION_MARK" $PYTHON_CONFIGURE_BZL_PATH
+then
+    sed -i '159i\ \ \ \ python_bin_path=repository_ctx.which("python3")\n\ \ \ \ if\ python_bin_path != None:\n\ \ \ \ \ \ \ \ return\ str(python_bin_path)' $PYTHON_CONFIGURE_BZL_PATH
+    sed -i '18s/py/third_party\/pybind11_bazel\/py/' $PYTHON_CONFIGURE_BZL_PATH
+    sed -i '12iPYBIND11_BAZEL_DIR = "//third_party/pybind11_bazel"' $PYTHON_CONFIGURE_BZL_PATH
+    sed -i "8i$EDITION_MARK" $PYTHON_CONFIGURE_BZL_PATH
+fi
+
 PARAMS=""
 while (( "$#" )); do
   case "$1" in
-    -f|--first_time)
-        FARG=$2
-        echo "-f option passed"
-        shift 2
-        sed -i '159i\ \ \ \ python_bin_path=repository_ctx.which("python3")\n\ \ \ \ if\ python_bin_path != None:\n\ \ \ \ \ \ \ \ return\ str(python_bin_path)' ./third_party/pybind11_bazel/python_configure.bzl
-        sed -i '18s/py/third_party\/pybind11_bazel\/py/' ./third_party/pybind11_bazel/python_configure.bzl
-        sed -i '12iPYBIND11_BAZEL_DIR = "//third_party/pybind11_bazel"' ./third_party/pybind11_bazel/python_configure.bzl
-        break
-        ;; 
     --) # end argument parsing
       shift
       break

--- a/contributing.md
+++ b/contributing.md
@@ -9,7 +9,7 @@ The project uses [Pybind11](http://pybind11.readthedocs.io) to wrap Google's [Di
 Two installation scripts are available to help get your environment ready set up:
 - ext_source_setup - This clones Google's differential privacy library as well as some other third party dependencies.
 - prereqs - This script automates the installation of the prerequisite packages to get you started, you can optionally install these manually referring to the list below.
-- Run the command: ```build_PyDP.sh -f```
+- Run the command: ```build_PyDP.sh```
 
 It is worth noting that whilst you can absolutely set up a Windows environment, it is a lot simpler to get started with Linux. For Windows 10 users, we'd highly recommend the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) and the very handly [Remote - WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extension for VS Code.
 


### PR DESCRIPTION
## Removal of the "first time" flag from the build script

This flag is currently used to make sure that `python_configure.bzl` will only be edited once. The edition can instead be marked in the file (see code).

I believe the flag removal simplifies the setup and makes it easier to dockerize soon (#61). Docker needs to run the script when building, but for development the repo directory should be shared with the host. Running `build_PyDP.sh` on the host before building the image should not affect the image building process.

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

From the project directory go to the pybind11_bazel directory and restore original file version:
```
cd third_party/pybind11_bazel/
git reset --hard
```
Go back to the project directory and run the script there (`./build_PyDP.sh` note no `-f` flag). Observe there is the expected change in the file and a second run does not affect the file anymore.

Did you run `make test-all`?
Yes. I'm getting a completely unrelated error :slightly_smiling_face:  :
```python
E       AttributeError: module 'pydp' has no attribute 'status_code_to_string'
```

## Checklist:

- [ ] New Unit tests added
- [ ] Unit tests pass locally with my changes