### PR TITLE
Update scope of status_code_to_string inside test

### DIFF
--- a/tests/base/test_status.py
+++ b/tests/base/test_status.py
@@ -5,28 +5,28 @@ import pydp as pd
 
 class TestStatus():
     def test_hello(self):
-        i =1 
+        i =1
         assert 1 == i
 
     def test_status_codes(self):
         status_code_available = [
-            "StatusCode.kOk", 
-            "StatusCode.kCancelled", 
-            "StatusCode.kUnknown", 
+            "StatusCode.kOk",
+            "StatusCode.kCancelled",
+            "StatusCode.kUnknown",
             "StatusCode.kInvalidArgument",
-            "StatusCode.kDeadlineExceeded", 
-            "StatusCode.kNotFound", 
-            "StatusCode.kAlreadyExists", 
-            "StatusCode.kPermissionDenied", 
-            "StatusCode.kResourceExhausted", 
+            "StatusCode.kDeadlineExceeded",
+            "StatusCode.kNotFound",
+            "StatusCode.kAlreadyExists",
+            "StatusCode.kPermissionDenied",
+            "StatusCode.kResourceExhausted",
             "StatusCode.kFailedPrecondition",
-            "StatusCode.kAborted", 
+            "StatusCode.kAborted",
             "StatusCode.kOutOfRange",
             "StatusCode.kUnimplemented",
-            "StatusCode.kInternal", 
-            "StatusCode.kUnavailable", 
-            "StatusCode.kDataLoss", 
-            "StatusCode.kUnauthenticated", 
+            "StatusCode.kInternal",
+            "StatusCode.kUnavailable",
+            "StatusCode.kDataLoss",
+            "StatusCode.kUnauthenticated",
         ]
         actual_codes = []
         x = range(17)
@@ -34,9 +34,9 @@ class TestStatus():
             actual_codes.append(str(pd.Status.StatusCode(n)))
         print(actual_codes)
         assert status_code_available == actual_codes
-    
+
     def test_code_to_string(self):
-        s = pd.status_code_to_string(pd.Status.StatusCode(3))
+        s = pd.Status.status_code_to_string(pd.Status.StatusCode(3))
         assert s == "kInvalidArgument"
 
 class TestSampleLoad():
@@ -47,7 +47,7 @@ class TestSampleLoad():
         payload_content = "example payload content"
         s.set_payload(url, payload_content)
         assert s.get_payload(url) == None
-    
+
     def test_payload_test_1(self):
         # in all Status code except 0, payload is added
         s = pd.Status(pd.Status.StatusCode(1), "New status object")


### PR DESCRIPTION
## Description

The previous test coverage considered the function `status_code_to_string` to be at the main package level. Now the test code properly invokes it from the `Status` subpackage, as the binding code indicates.

Fixes #90

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Executed `make test-all` and 11/11 tests passed.

## Checklist:

- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes