### PR TITLE
Fix docstrings in logging.cpp

### DIFF
--- a/src/bindings/PyDP/base/logging.cpp
+++ b/src/bindings/PyDP/base/logging.cpp
@@ -15,7 +15,7 @@ void init_base_logging(py::module &m) {
 
     auto msub = m.def_submodule("logging");
 
-    msub.def("get_log_directory", &dpbase::get_log_directory), "Get th current logging directory";
-    msub.def("get_vlog_level", &dpbase::get_vlog_level), "Get the current logging verbosity level";
-    msub.def("init_logging", &dpbase::InitLogging), "Begin logging";
+    msub.def("get_log_directory", &dpbase::get_log_directory, "Get the current logging directory");
+    msub.def("get_vlog_level", &dpbase::get_vlog_level, "Get the current logging verbosity level");
+    msub.def("init_logging", &dpbase::InitLogging, "Begin logging");
 }


### PR DESCRIPTION
## Description

This is a partial fix of docstrings in `logging.cpp`

Currently the building process produces these messages about unused values (parentheses misplacement):
```
INFO: From Compiling src/bindings/PyDP/base/logging.cpp:
src/bindings/PyDP/base/logging.cpp: In function 'void init_base_logging(pybind11::module&)':
src/bindings/PyDP/base/logging.cpp:18:98: warning: right operand of comma operator has no effect [-Wunused-value]
     msub.def("get_log_directory", &dpbase::get_log_directory), "Get th current logging directory";
                                                                                                  ^
src/bindings/PyDP/base/logging.cpp:19:99: warning: right operand of comma operator has no effect [-Wunused-value]
     msub.def("get_vlog_level", &dpbase::get_vlog_level), "Get the current logging verbosity level";
                                                                                                   ^
src/bindings/PyDP/base/logging.cpp:20:68: warning: right operand of comma operator has no effect [-Wunused-value]
     msub.def("init_logging", &dpbase::InitLogging), "Begin logging";
```

Unfortunately even after parentheses are fixed the docstrings are still unavailable in Python:
`help(logging.get_log_directory)` gives me only:
```
Help on built-in function get_log_directory in module pydp.pydp.logging:

get_log_directory(...) method of builtins.PyCapsule instance
    get_log_directory() -> str
```

Docstrings from `status.cpp` work as expected.

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Did you run `make test-all`?
Yes. The change doesn't break anything.

## Checklist:

- [ ] New Unit tests added
- [x] Unit tests pass locally with my changes