### PR TITLE
Add BoundedMean (work in progress)

### DIFF
--- a/src/bindings/BUILD
+++ b/src/bindings/BUILD
@@ -21,6 +21,7 @@ pybind_extension(
         "@google_dp//differential_privacy/base:canonical_errors",
         "@google_dp//differential_privacy/base:statusor",
         "@google_dp//differential_privacy/algorithms:algorithm",
+        "@google_dp//differential_privacy/algorithms:bounded-mean",
         "@google_dp//differential_privacy/algorithms:bounded-sum",
         "@google_dp//differential_privacy/algorithms:count",
         "@google_dp//differential_privacy/proto:data_cc_proto"

--- a/src/bindings/PyDP/algorithms/algorithms.cpp
+++ b/src/bindings/PyDP/algorithms/algorithms.cpp
@@ -9,6 +9,7 @@
 #include "../pydp_lib/casting.hpp" // our caster helper library
 
 #include "differential_privacy/algorithms/algorithm.h"
+#include "differential_privacy/algorithms/bounded-mean.h"
 #include "differential_privacy/algorithms/bounded-sum.h"
 #include "differential_privacy/algorithms/bounded-algorithm.h"
 #include "differential_privacy/algorithms/count.h"
@@ -54,9 +55,25 @@ namespace dp = differential_privacy;
               nullptr>
     void declareBoundedSum(py::module & m, string const & suffix) {
         py::class_<dp::BoundedSum<T>> cls(m, ("BoundedSum" + suffix).c_str());
+        py::class_<typename dp::BoundedSum<T>::Builder> bld(cls, "Builder");
+        bld.def(py::init<>());
     }
 
+    template <typename T,
+          typename std::enable_if<std::is_integral<T>::value ||
+                                  std::is_floating_point<T>::value>::type* =
+              nullptr>
+    void declareBoundedMean(py::module & m, string const & suffix) {
+      py::class_<dp::BoundedMean<T>> cls(m, ("BoundedMean" + suffix).c_str());
 
+      py::class_<typename dp::BoundedMean<T>::Builder> bld(cls, "Builder");
+      bld.def(py::init<>());
+      bld.def("set_epsilon", &dp::BoundedMean<T>::Builder::SetEpsilon);
+      bld.def("set_lower", &dp::BoundedMean<T>::Builder::SetLower);
+      bld.def("set_upper", &dp::BoundedMean<T>::Builder::SetUpper);
+      bld.def("clear_bounds", &dp::BoundedMean<T>::Builder::ClearBounds);
+      bld.def("build", &dp::BoundedMean<T>::Builder::Build);
+    }
     //todo: make these generators work. refer to the statusor implementation for inspiration
     // template<typename T>
     // void declareCount(py::module & m, string const & suffix) {
@@ -86,5 +103,8 @@ void init_algorithms(py::module &m) {
 
     declareBoundedSum<int>(m,"I");
     declareBoundedAlgorithmBuilder<int,dp::BoundedSum<int>, typename dp::BoundedSum<int>::Builder>(m,"I");
+
+    declareBoundedMean<int>(m, "Int");
+    //declareBoundedAlgorithmBuilder<int,dp::BoundedMean<int>, typename dp::BoundedMean<int>::Builder>(m,"II");
 
 }

--- a/src/bindings/PyDP/base/status.cpp
+++ b/src/bindings/PyDP/base/status.cpp
@@ -10,6 +10,7 @@
 #include "differential_privacy/base/status.h" // the header file associated with status.cc
 #include "differential_privacy/base/canonical_errors.h" // the header file associated with status.cc
 #include "differential_privacy/base/statusor.h" //header file associated with statusor.cc
+#include "differential_privacy/algorithms/bounded-mean.h"
 #include "differential_privacy/proto/data.pb.h" // for Output type
 
 using namespace std;
@@ -27,9 +28,23 @@ void declareStatusOr(py::module & m, string const & suffix) {
     cls.def(py::init<T>(), "value"_a);
     cls.def(py::init<dp::base::Status>(), "status"_a);
     cls.def("ok", &dp::base::StatusOr<T>::ok);
+    //cls.def("value_or_die", &dp::base::StatusOr<T>::ValueOrDie<T>);
     //cls.def(py::self == dpbase::Status());
 
 }
+
+
+template<class Algorithm>
+ void declareStatusOr2(py::module & m, string const & suffix) {
+   py::class_<dp::base::StatusOr<Algorithm>> cls(m, ("StatusOr" + suffix).c_str());
+   cls.def(py::init<>());
+   //cls.def(py::init<Algorithm>(), "value"_a);
+   cls.def(py::init<dp::base::Status>(), "status"_a);
+   cls.def("ok", &dp::base::StatusOr<Algorithm>::ok);
+   //cls.def("value_or_die", &dp::base::StatusOr<T>::ValueOrDie<T>);
+   //cls.def(py::self == dpbase::Status());
+}
+
 
 void init_base_status(py::module &m) {
 
@@ -96,6 +111,10 @@ void init_base_status(py::module &m) {
     declareStatusOr<double>(m, "D");
     declareStatusOr<dp::Output>(m, "O");
 
+
+    // declareStatusOr2 is only a little different from declareStatusOr
+    // (see above in this file).
+    // Using declareStatusOr (without "2" at the end) below results in this error:
+    // external/google_dp/differential_privacy/base/statusor_internals.h:104:60: error: use of deleted function 'differential_privacy::BoundedMean<int>::BoundedMean(differential_privacy::BoundedMean<int>&&)'
+    declareStatusOr2<typename dp::BoundedMean<int>>(m, "BoundedMeantInt");
 }
-
-

--- a/src/bindings/PyDP/pydp_lib/casting.hpp
+++ b/src/bindings/PyDP/pydp_lib/casting.hpp
@@ -6,6 +6,8 @@
 #include "absl/strings/string_view.h"
 #include "absl/types/optional.h"
 
+#include "differential_privacy/algorithms/bounded-mean.h"
+
 namespace pybind11 {
     namespace detail
     {
@@ -14,5 +16,15 @@ namespace pybind11 {
 
         template <typename T>
         struct type_caster<absl::optional<T>> : optional_caster<absl::optional<T>> {};
-    }   
+
+
+      // It compiles but it's probably completely useless:
+      template <typename T>
+       struct type_caster<std::unique_ptr<differential_privacy::BoundedMean<T>>> {
+         static handle cast(std::unique_ptr<differential_privacy::BoundedMean<T>> src, return_value_policy /* policy */, handle /* parent */) {
+           return static_cast<typename differential_privacy::BoundedMean<T>>(*src);
+         };
+      };
+
+    }
 }

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -1,0 +1,29 @@
+import pytest
+import pydp as dp
+
+
+class TestBoundedMean():
+
+    def test_basic(self):
+        a = [2, 4, 6, 8]
+        mean = dp.BoundedMeanInt.Builder().set_epsilon(1.0). \
+               set_lower(1).set_upper(9).build().value_or_die()
+        assert 1 < dp.get_value(mean.result(a).value_or_die()) < 9
+
+# TODO: port this test
+#
+# TYPED_TEST(BoundedMeanTest, BasicTest) {
+#   std::vector<TypeParam> a = {2, 4, 6, 8};
+#   std::unique_ptr<BoundedMean<TypeParam>> mean =
+#       typename BoundedMean<TypeParam>::Builder()
+#           .SetEpsilon(1.0)
+#           .SetLower(1)
+#           .SetUpper(9)
+#           .Build()
+#           .ValueOrDie();
+#   Output result = mean->Result(a.begin(), a.end()).ValueOrDie();
+#   EXPECT_GE(GetValue<double>(result), 1);
+#   EXPECT_LE(GetValue<double>(result), 9);
+# }
+#
+# TODO: port remaining tests from the C++ library


### PR DESCRIPTION
## Description
This is a work in progress (related to #18)

A nested Builder class is created correctly, but the return value of `build` method is not converted to a Python type:
```
>>> import pydp as dp
>>> dp.BoundedMeanInt.Builder().set_epsilon(1.0).set_lower(1).set_upper(9).build
<bound method PyCapsule.build of <pydp.pydp.BoundedMeanInt.Builder object at 0x7f77beb2f730>>
>>> dp.BoundedMeanInt.Builder().set_epsilon(1.0).set_lower(1).set_upper(9).build()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: Unable to convert function return value to a Python type! The signature was
	(self: pydp.pydp.BoundedMeanInt.Builder) -> differential_privacy::base::StatusOr<std::unique_ptr<differential_privacy::BoundedMean<int, (void*)0>, std::default_delete<differential_privacy::BoundedMean<int, (void*)0> > > >

Did you forget to `#include <pybind11/stl.h>`? Or <pybind11/complex.h>,
<pybind11/functional.h>, <pybind11/chrono.h>, etc. Some automatic
conversions are optional and require extra headers to be included
when compiling your pybind11 module.
```
A `StatusOr` class for `BoundedMean<int>` is declared on the Python side in `status.cpp`.