### PR TITLE
Added bindings for order statistics

### DIFF
--- a/src/bindings/BUILD
+++ b/src/bindings/BUILD
@@ -26,6 +26,7 @@ pybind_extension(
         "@google_dp//differential_privacy/algorithms:bounded-mean",
         "@google_dp//differential_privacy/algorithms:bounded-sum",
         "@google_dp//differential_privacy/algorithms:count",
+        "@google_dp//differential_privacy/algorithms:order-statistics",
         "@google_dp//differential_privacy/proto:data_cc_proto"
     ],
 )

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -1,39 +1,27 @@
 // Provides bindings for Bounded Functions
 
 #include "../../c/c_api.h"
+
 #include "../pydp_lib/casting.hpp"  // our caster helper library
+#include "../pydp_lib/helper_class.hpp"  //  Dummy helper class
+
 #include "pybind11/complex.h"
 #include "pybind11/functional.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
 
-PYBIND11_MAKE_OPAQUE(BoundedFunctionHelperObject);
-
 using namespace std;
 
 namespace py = pybind11;
 
 
-class BoundedMeanDummy {
+class BoundedMeanDummy :public Dummy{
  public:
-  BoundedMeanDummy(double epsilon, int lower, int upper) {
-    obj = NewBoundedFunctionObject(epsilon, lower, upper);
-  }
-
-  BoundedMeanDummy(double epsilon) {
-    obj = NewBoundedFunctionObject1(epsilon);
-  }
-
-  double Result(py::list l) {
+  using Dummy::Dummy;
+  double Result(py::list l) override{
     return Result_BoundedMean(obj, l);
   }
-
-  ~BoundedMeanDummy() {
-    DeleteBoundedFunctionObject(obj);
-  }
-
-  BoundedFunctionHelperObject* obj;
 };
 
 void declareBoundedMean(py::module& m) {

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -2,7 +2,7 @@
 
 #include "../../c/c_api.h"
 
-#include "../pydp_lib/casting.hpp"  // our caster helper library
+#include "../pydp_lib/casting.hpp"       // our caster helper library
 #include "../pydp_lib/helper_class.hpp"  //  Dummy helper class
 
 #include "pybind11/complex.h"
@@ -10,16 +10,14 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
-
 using namespace std;
 
 namespace py = pybind11;
 
-
-class BoundedMeanDummy :public Dummy{
+class BoundedMeanDummy : public Dummy {
  public:
   using Dummy::Dummy;
-  double Result(py::list l) override{
+  double Result(py::list l) override {
     return Result_BoundedMean(obj, l);
   }
 };

--- a/src/bindings/PyDP/algorithms/order_statistics.cpp
+++ b/src/bindings/PyDP/algorithms/order_statistics.cpp
@@ -2,7 +2,7 @@
 
 #include "../../c/c_api.h"
 
-#include "../pydp_lib/casting.hpp"  // our caster helper library
+#include "../pydp_lib/casting.hpp"       // our caster helper library
 #include "../pydp_lib/helper_class.hpp"  //  Dummy helder class
 
 #include "pybind11/complex.h"
@@ -10,58 +10,55 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
-
 using namespace std;
 
 namespace py = pybind11;
 
-
-class MaxDummy : public Dummy{
-  public:
+class MaxDummy : public Dummy {
+ public:
   using Dummy::Dummy;
 
-  double Result(py::list l, double privacy_budget) override{
+  double Result(py::list l, double privacy_budget) override {
     return Result_Max(obj, l, privacy_budget);
   }
 };
 
-class MinDummy : public Dummy{
+class MinDummy : public Dummy {
  public:
   using Dummy::Dummy;
 
-  double Result(py::list l, double privacy_budget) override{
+  double Result(py::list l, double privacy_budget) override {
     return Result_Min(obj, l, privacy_budget);
   }
 };
 
-class MedianDummy : public Dummy{
+class MedianDummy : public Dummy {
  public:
   using Dummy::Dummy;
 
-  double Result(py::list l, double privacy_budget) override{
+  double Result(py::list l, double privacy_budget) override {
     return Result_Median(obj, l, privacy_budget);
   }
 };
 
-class PercentileDummy : public Dummy{
+class PercentileDummy : public Dummy {
  public:
   using Dummy::Dummy;
-  
-  void setPercentile(double percentile){
+
+  void setPercentile(double percentile) {
     _percentile = percentile;
   }
 
-  double getPercentile(){
+  double getPercentile() {
     return _percentile;
   }
 
-  double Result(py::list l, double privacy_budget) override{
+  double Result(py::list l, double privacy_budget) override {
     return Result_Percentile(obj, l, privacy_budget, _percentile);
   }
 
  private:
   double _percentile = 0.45;
-
 };
 
 void declareMax(py::module& m) {
@@ -102,9 +99,9 @@ void declarePercentile(py::module& m) {
   bld.def(py::init<double>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def("result", &PercentileDummy::Result);
-  bld.def_property("percentile", &PercentileDummy::getPercentile, &PercentileDummy::setPercentile);
+  bld.def_property("percentile", &PercentileDummy::getPercentile,
+                   &PercentileDummy::setPercentile);
 }
-
 
 void init_algorithms_order_statistics(py::module& m) {
   declareMax(m);

--- a/src/bindings/PyDP/algorithms/order_statistics.cpp
+++ b/src/bindings/PyDP/algorithms/order_statistics.cpp
@@ -1,0 +1,114 @@
+// Provides bindings for Bounded Functions
+
+#include "../../c/c_api.h"
+
+#include "../pydp_lib/casting.hpp"  // our caster helper library
+#include "../pydp_lib/helper_class.hpp"  //  Dummy helder class
+
+#include "pybind11/complex.h"
+#include "pybind11/functional.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+
+using namespace std;
+
+namespace py = pybind11;
+
+
+class MaxDummy : public Dummy{
+  public:
+  using Dummy::Dummy;
+
+  double Result(py::list l, double privacy_budget) override{
+    return Result_Max(obj, l, privacy_budget);
+  }
+};
+
+class MinDummy : public Dummy{
+ public:
+  using Dummy::Dummy;
+
+  double Result(py::list l, double privacy_budget) override{
+    return Result_Min(obj, l, privacy_budget);
+  }
+};
+
+class MedianDummy : public Dummy{
+ public:
+  using Dummy::Dummy;
+
+  double Result(py::list l, double privacy_budget) override{
+    return Result_Median(obj, l, privacy_budget);
+  }
+};
+
+class PercentileDummy : public Dummy{
+ public:
+  using Dummy::Dummy;
+  
+  void setPercentile(double percentile){
+    _percentile = percentile;
+  }
+
+  double getPercentile(){
+    return _percentile;
+  }
+
+  double Result(py::list l, double privacy_budget) override{
+    return Result_Percentile(obj, l, privacy_budget, _percentile);
+  }
+
+ private:
+  double _percentile = 0.45;
+
+};
+
+void declareMax(py::module& m) {
+  py::class_<MaxDummy> bld(m, "Max");
+
+  bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def("result", &MaxDummy::Result);
+}
+
+void declareMin(py::module& m) {
+  py::class_<MinDummy> bld(m, "Min");
+
+  bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def("result", &MinDummy::Result);
+}
+
+void declareMedian(py::module& m) {
+  py::class_<MedianDummy> bld(m, "Median");
+
+  bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def("result", &MedianDummy::Result);
+}
+
+void declarePercentile(py::module& m) {
+  py::class_<PercentileDummy> bld(m, "Percentile");
+
+  bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  bld.def("result", &PercentileDummy::Result);
+  bld.def_property("percentile", &PercentileDummy::getPercentile, &PercentileDummy::setPercentile);
+}
+
+
+void init_algorithms_order_statistics(py::module& m) {
+  declareMax(m);
+  declareMin(m);
+  declareMedian(m);
+  declarePercentile(m);
+}

--- a/src/bindings/PyDP/bindings.cpp
+++ b/src/bindings/PyDP/bindings.cpp
@@ -9,7 +9,7 @@ void init_base_status(py::module &);
 void init_base_logging(py::module &);
 void init_base_percentile(py::module &);
 
-// algorithms
+// bounded functions
 void init_algorithms_bounded_functions(py::module &);
 
 // util
@@ -17,6 +17,9 @@ void init_algorithms_util(py::module &);
 
 // distributions
 void init_algorithms_distributions(py::module &);
+
+// order statistics
+void init_algorithms_order_statistics(py::module &);
 
 // proto
 void init_proto(py::module &);
@@ -33,6 +36,7 @@ PYBIND11_MODULE(pydp, m) {
   init_algorithms_bounded_functions(m);
   init_algorithms_util(m);
   init_algorithms_distributions(m);
+  init_algorithms_order_statistics(m);
 
   // Proto
   init_proto(m);

--- a/src/bindings/PyDP/pydp_lib/helper_class.hpp
+++ b/src/bindings/PyDP/pydp_lib/helper_class.hpp
@@ -4,7 +4,6 @@
 #include "pybind11/pybind11.h"
 #include "pybind11/stl.h"
 
-
 PYBIND11_MAKE_OPAQUE(BoundedFunctionHelperObject);
 
 using namespace std;
@@ -21,11 +20,9 @@ class Dummy {
     obj = NewBoundedFunctionObject1(epsilon);
   }
 
-  virtual double Result(py::list) {
-  }
+  virtual double Result(py::list) {}
 
-  virtual double Result(py::list, double) {
-  }
+  virtual double Result(py::list, double) {}
 
   ~Dummy() {
     DeleteBoundedFunctionObject(obj);

--- a/src/bindings/PyDP/pydp_lib/helper_class.hpp
+++ b/src/bindings/PyDP/pydp_lib/helper_class.hpp
@@ -1,0 +1,35 @@
+#include "../../c/c_api.h"
+#include "pybind11/complex.h"
+#include "pybind11/functional.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
+
+
+PYBIND11_MAKE_OPAQUE(BoundedFunctionHelperObject);
+
+using namespace std;
+
+namespace py = pybind11;
+
+class Dummy {
+ public:
+  Dummy(double epsilon, int lower, int upper) {
+    obj = NewBoundedFunctionObject(epsilon, lower, upper);
+  }
+
+  Dummy(double epsilon) {
+    obj = NewBoundedFunctionObject1(epsilon);
+  }
+
+  virtual double Result(py::list) {
+  }
+
+  virtual double Result(py::list, double) {
+  }
+
+  ~Dummy() {
+    DeleteBoundedFunctionObject(obj);
+  }
+
+  BoundedFunctionHelperObject* obj;
+};

--- a/src/bindings/c/c_api.cc
+++ b/src/bindings/c/c_api.cc
@@ -1,6 +1,12 @@
 #include "c_api.h"
 
+#include "differential_privacy/algorithms/algorithm.h"
+
 #include "differential_privacy/algorithms/bounded-mean.h"
+
+#include "differential_privacy/algorithms/order-statistics.h"
+#include "absl/random/distributions.h"
+
 #include "pybind11/pybind11.h"
 
 extern "C" {
@@ -31,6 +37,114 @@ double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list l)
   Output result = mean->Result(a.begin(), a.end()).ValueOrDie();
 
   return GetValue<double>(result);
+}
+
+// Order Statistics
+
+// Max
+
+int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+  std::unique_ptr<continuous::Max<int64_t>> search;
+  if (has_bounds) {
+    search = 
+      continuous::Max<int64_t>::Builder()
+          .SetEpsilon(config->epsilon)
+          .SetLower(config->lower)
+          .SetUpper(config->upper)
+          .Build()
+          .ValueOrDie();
+  }
+  else{
+    search = 
+      continuous::Max<int64_t>::Builder()
+          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+  }
+
+  for (auto i : l) {
+    search->AddEntry(i.cast<double>());
+  }
+    
+  return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
+}
+
+// Min
+
+int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+  std::unique_ptr<continuous::Min<int64_t>> search;
+  if (has_bounds) {
+    search = 
+      continuous::Min<int64_t>::Builder()
+          .SetEpsilon(config->epsilon)
+          .SetLower(config->lower)
+          .SetUpper(config->upper)
+          .Build()
+          .ValueOrDie();
+  }
+  else{
+    search = 
+      continuous::Min<int64_t>::Builder()
+          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+  }
+
+  for (auto i : l) {
+    search->AddEntry(i.cast<double>());
+  }
+    
+  return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
+}
+
+// Max
+
+int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+  std::unique_ptr<continuous::Median<int64_t>> search;
+  if (has_bounds) {
+    search = 
+      continuous::Median<int64_t>::Builder()
+          .SetEpsilon(config->epsilon)
+          .SetLower(config->lower)
+          .SetUpper(config->upper)
+          .Build()
+          .ValueOrDie();
+  }
+  else{
+    search = 
+      continuous::Median<int64_t>::Builder()
+          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+  }
+
+  for (auto i : l) {
+    search->AddEntry(i.cast<double>());
+  }
+    
+  return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
+}
+
+// Percentile
+
+int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget, 
+                            double percentile) {
+  std::unique_ptr<continuous::Percentile<int64_t>> search;
+  if (has_bounds) {
+    search = 
+      continuous::Percentile<int64_t>::Builder()
+          .SetPercentile(percentile)
+          .SetEpsilon(config->epsilon)
+          .SetLower(config->lower)
+          .SetUpper(config->upper)
+          .Build()
+          .ValueOrDie();
+  }
+  else{
+    search = 
+      continuous::Percentile<int64_t>::Builder()
+        .SetPercentile(percentile).SetEpsilon(config->epsilon).Build().ValueOrDie();
+  }
+
+  for (auto i : l) {
+    search->AddEntry(i.cast<double>());
+  }
+    
+  return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
 }
 
 // Common functions

--- a/src/bindings/c/c_api.cc
+++ b/src/bindings/c/c_api.cc
@@ -4,8 +4,8 @@
 
 #include "differential_privacy/algorithms/bounded-mean.h"
 
-#include "differential_privacy/algorithms/order-statistics.h"
 #include "absl/random/distributions.h"
+#include "differential_privacy/algorithms/order-statistics.h"
 
 #include "pybind11/pybind11.h"
 
@@ -43,113 +43,114 @@ double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list l)
 
 // Max
 
-int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list l,
+                   double privacy_budget) {
   std::unique_ptr<continuous::Max<int64_t>> search;
   if (has_bounds) {
-    search = 
-      continuous::Max<int64_t>::Builder()
-          .SetEpsilon(config->epsilon)
-          .SetLower(config->lower)
-          .SetUpper(config->upper)
-          .Build()
-          .ValueOrDie();
-  }
-  else{
-    search = 
-      continuous::Max<int64_t>::Builder()
-          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+    search = continuous::Max<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .SetLower(config->lower)
+                 .SetUpper(config->upper)
+                 .Build()
+                 .ValueOrDie();
+  } else {
+    search = continuous::Max<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .Build()
+                 .ValueOrDie();
   }
 
   for (auto i : l) {
     search->AddEntry(i.cast<double>());
   }
-    
+
   return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
 }
 
 // Min
 
-int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list l,
+                   double privacy_budget) {
   std::unique_ptr<continuous::Min<int64_t>> search;
   if (has_bounds) {
-    search = 
-      continuous::Min<int64_t>::Builder()
-          .SetEpsilon(config->epsilon)
-          .SetLower(config->lower)
-          .SetUpper(config->upper)
-          .Build()
-          .ValueOrDie();
-  }
-  else{
-    search = 
-      continuous::Min<int64_t>::Builder()
-          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+    search = continuous::Min<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .SetLower(config->lower)
+                 .SetUpper(config->upper)
+                 .Build()
+                 .ValueOrDie();
+  } else {
+    search = continuous::Min<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .Build()
+                 .ValueOrDie();
   }
 
   for (auto i : l) {
     search->AddEntry(i.cast<double>());
   }
-    
+
   return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
 }
 
 // Max
 
-int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget) {
+int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list l,
+                      double privacy_budget) {
   std::unique_ptr<continuous::Median<int64_t>> search;
   if (has_bounds) {
-    search = 
-      continuous::Median<int64_t>::Builder()
-          .SetEpsilon(config->epsilon)
-          .SetLower(config->lower)
-          .SetUpper(config->upper)
-          .Build()
-          .ValueOrDie();
-  }
-  else{
-    search = 
-      continuous::Median<int64_t>::Builder()
-          .SetEpsilon(config->epsilon).Build().ValueOrDie();
+    search = continuous::Median<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .SetLower(config->lower)
+                 .SetUpper(config->upper)
+                 .Build()
+                 .ValueOrDie();
+  } else {
+    search = continuous::Median<int64_t>::Builder()
+                 .SetEpsilon(config->epsilon)
+                 .Build()
+                 .ValueOrDie();
   }
 
   for (auto i : l) {
     search->AddEntry(i.cast<double>());
   }
-    
+
   return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
 }
 
 // Percentile
 
-int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list l, double privacy_budget, 
-                            double percentile) {
+int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list l,
+                          double privacy_budget, double percentile) {
   std::unique_ptr<continuous::Percentile<int64_t>> search;
   if (has_bounds) {
-    search = 
-      continuous::Percentile<int64_t>::Builder()
-          .SetPercentile(percentile)
-          .SetEpsilon(config->epsilon)
-          .SetLower(config->lower)
-          .SetUpper(config->upper)
-          .Build()
-          .ValueOrDie();
-  }
-  else{
-    search = 
-      continuous::Percentile<int64_t>::Builder()
-        .SetPercentile(percentile).SetEpsilon(config->epsilon).Build().ValueOrDie();
+    search = continuous::Percentile<int64_t>::Builder()
+                 .SetPercentile(percentile)
+                 .SetEpsilon(config->epsilon)
+                 .SetLower(config->lower)
+                 .SetUpper(config->upper)
+                 .Build()
+                 .ValueOrDie();
+  } else {
+    search = continuous::Percentile<int64_t>::Builder()
+                 .SetPercentile(percentile)
+                 .SetEpsilon(config->epsilon)
+                 .Build()
+                 .ValueOrDie();
   }
 
   for (auto i : l) {
     search->AddEntry(i.cast<double>());
   }
-    
+
   return GetValue<int64_t>(search->PartialResult(privacy_budget).ValueOrDie());
 }
 
 // Common functions
 
-BoundedFunctionHelperObject* NewBoundedFunctionObject(double epsilon, int lower, int upper) {
+BoundedFunctionHelperObject* NewBoundedFunctionObject(double epsilon, int lower,
+                                                      int upper) {
   has_bounds = true;
   return new BoundedFunctionHelperObject{epsilon, lower, upper};
 }

--- a/src/bindings/c/c_api.h
+++ b/src/bindings/c/c_api.h
@@ -19,7 +19,8 @@ typedef struct BoundedFunctionHelperObject {
 
 } BoundedFunctionHelperObject;
 
-extern BoundedFunctionHelperObject* NewBoundedFunctionObject(double epsilon, int lower, int upper);
+extern BoundedFunctionHelperObject* NewBoundedFunctionObject(double epsilon, int lower,
+                                                             int upper);
 
 extern BoundedFunctionHelperObject* NewBoundedFunctionObject1(double epsilon);
 
@@ -29,14 +30,17 @@ extern void DeleteBoundedFunctionObject(BoundedFunctionHelperObject* config);
 extern double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list a);
 
 // Order statistics
-extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a,
+                          double privacy_budget);
 
-extern int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+extern int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list a,
+                          double privacy_budget);
 
-extern int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+extern int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list a,
+                             double privacy_budget);
 
-extern int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget, double percentile);
-
+extern int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list a,
+                                 double privacy_budget, double percentile);
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/src/bindings/c/c_api.h
+++ b/src/bindings/c/c_api.h
@@ -28,6 +28,16 @@ extern void DeleteBoundedFunctionObject(BoundedFunctionHelperObject* config);
 // Bounded Mean
 extern double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list a);
 
+// Order statistics
+extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+
+extern int64_t Result_Min(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+
+extern int64_t Result_Median(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget);
+
+extern int64_t Result_Percentile(BoundedFunctionHelperObject* config, pybind11::list a, double privacy_budget, double percentile);
+
+
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -19,7 +19,7 @@ class TestBoundedMean:
         a = [2, 4, 6, 8]
 
         mean_algorithm = dp.BoundedMean(1.0, 1, 9)
-        assert 1 < dp.mean_algorithm.result(a) < 9
+        assert 1.0 <= mean_algorithm.result(a) <= 9.0
 
 
 # TODO: port this test

--- a/tests/algorithms/test_order_statistics.py
+++ b/tests/algorithms/test_order_statistics.py
@@ -1,0 +1,82 @@
+import pytest
+
+# verify with actual value
+import statistics
+import math
+
+import pydp as dp
+
+
+@pytest.fixture
+def data():
+    kDataSize = 10000
+    a = []
+    for i in range(kDataSize):
+        a.append(200 * i / kDataSize)
+    return a
+
+
+def test_max(data):
+    maxx = dp.Max(1.0, 0, 2048)
+    assert 190 < maxx.result(data, 1.0) < 210
+
+    assert max(data) - 10 < maxx.result(data, 1.0) < max(data) + 10
+
+
+def test_min(data):
+    maxx = dp.Min(1.0, 0, 2048)
+
+    assert min(data) - 10 < maxx.result(data, 1.0) < min(data) + 10
+
+    assert -10 < maxx.result(data, 1.0) < 10
+
+
+def test_median(data):
+    maxx = dp.Median(1.0, 0, 2048)
+
+    assert statistics.median(data) - 20 < maxx.result(data, 1.0) \
+        < statistics.median(data) + 20
+
+    assert 90 <= maxx.result(data, 1.0) <= 100
+
+
+def test_median1(data):
+    maxx = dp.Median(1.0)
+    assert statistics.median(data) - 20 < maxx.result(data, 1.0) \
+        < statistics.median(data) + 20
+    assert 90 <= maxx.result(data, 1.0) <= 100
+
+
+def percentile(N, percent, key=lambda x:x):
+    """
+    Find the percentile of a list of values.
+
+    @parameter N - is a list of values. Note N MUST BE already sorted.
+    @parameter percent - a float value from 0.0 to 1.0.
+    @parameter key - optional key function to compute value from each element of N.
+
+    @return - the percentile of the values
+    """
+    if not N:
+        return None
+    k = (len(N) - 1) * percent
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return key(N[int(k)])
+    d0 = key(N[int(f)]) * (c - k)
+    d1 = key(N[int(c)]) * (k - f)
+    return d0 + d1
+
+
+def test_percentile(data):
+    maxx = dp.Percentile(1.0, 0, 2048)
+    maxx.percentile = 0.45
+
+    actual_percentile = int(percentile(data, 0.45))
+
+    assert maxx.percentile == 0.45
+    assert actual_percentile - 10 < maxx.result(data, 1.0) < actual_percentile + 10
+    assert 80 < maxx.result(data, 1.0) < 100
+
+# TODO Yet some more tests

--- a/tests/algorithms/test_order_statistics.py
+++ b/tests/algorithms/test_order_statistics.py
@@ -34,20 +34,26 @@ def test_min(data):
 def test_median(data):
     maxx = dp.Median(1.0, 0, 2048)
 
-    assert statistics.median(data) - 20 < maxx.result(data, 1.0) \
+    assert (
+        statistics.median(data) - 20
+        < maxx.result(data, 1.0)
         < statistics.median(data) + 20
+    )
 
     assert 90 <= maxx.result(data, 1.0) <= 100
 
 
 def test_median1(data):
     maxx = dp.Median(1.0)
-    assert statistics.median(data) - 20 < maxx.result(data, 1.0) \
+    assert (
+        statistics.median(data) - 20
+        < maxx.result(data, 1.0)
         < statistics.median(data) + 20
+    )
     assert 90 <= maxx.result(data, 1.0) <= 100
 
 
-def percentile(N, percent, key=lambda x:x):
+def percentile(N, percent, key=lambda x: x):
     """
     Find the percentile of a list of values.
 
@@ -78,5 +84,6 @@ def test_percentile(data):
     assert maxx.percentile == 0.45
     assert actual_percentile - 10 < maxx.result(data, 1.0) < actual_percentile + 10
     assert 80 < maxx.result(data, 1.0) < 100
+
 
 # TODO Yet some more tests


### PR DESCRIPTION
## Description

Added bindings for order statistics which adds, `Min`, `Max`, `Median `and `Percentile `Function

<!-- Depending on whether the PR fixes the Issue fully or partially -->

Fixes #25    <!-- The issue is fixed in whole (no futher work will be needed) -->

Partial issue # (issue) <!-- In-case the issue is partially fixed, i.e., still some work may be needed -->

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Yes, it passed bazel and pytest.

## Checklist:

- [x] New Unit tests added
- [x] Unit tests pass locally with my changes
