### PR TITLE
Add bindings for BoundedSum

### DIFF
--- a/examples/carrots.py
+++ b/examples/carrots.py
@@ -44,8 +44,10 @@ class CarrotReporter:
     def privacy_budget(self) -> float:
         return self._privacy_budget
 
+    # Function to return the DP sum of all carrots eaten.
     def private_sum(self, privacy_budget: float) -> dp.StatusOrO:
-        pass
+        x = dp.BoundedSum(privacy_budget)
+        return x.result(list(self._df["carrots_eaten"]))
 
     # Function to return the DP mean of all carrots eaten.
     def private_mean(self, privacy_budget: float) -> dp.StatusOrO:
@@ -74,5 +76,6 @@ print("Sum:\t" + str(c.sum_carrots()))
 print("Above 70:\t" + str(c.count_above(70)))
 print("Max:\t" + str(c.max()))
 print("private mean:\t" + str(c.private_mean(1)))
+print(f"private sum:\t {c.private_sum(c.epsilon)}")
 print("private max:\t" + str(c.private_max(1)))
 print("private count above:\t" + str(c.private_count_above(1, 70)))

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -22,6 +22,14 @@ class BoundedMeanDummy : public Dummy {
   }
 };
 
+class BoundedSumDummy : public Dummy {
+public:
+  using Dummy::Dummy;
+  double Result(py::list l) override {
+    return Result_BoundedSum(obj, l);
+  }
+};
+
 void declareBoundedMean(py::module& m) {
   py::class_<BoundedMeanDummy> bld(m, "BoundedMean");
 
@@ -32,6 +40,17 @@ void declareBoundedMean(py::module& m) {
   bld.def("result", &BoundedMeanDummy::Result);
 }
 
+void declareBoundedSum(py::module& m) {
+  py::class_<BoundedSumDummy> cls(m, "BoundedSum");
+
+  cls.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  cls.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  cls.def("result", &BoundedSumDummy::Result);
+}
+
 void init_algorithms_bounded_functions(py::module& m) {
   declareBoundedMean(m);
+  declareBoundedSum(m);
 }

--- a/src/bindings/c/c_api.cc
+++ b/src/bindings/c/c_api.cc
@@ -3,6 +3,7 @@
 #include "differential_privacy/algorithms/algorithm.h"
 
 #include "differential_privacy/algorithms/bounded-mean.h"
+#include "differential_privacy/algorithms/bounded-sum.h"
 
 #include "absl/random/distributions.h"
 #include "differential_privacy/algorithms/order-statistics.h"
@@ -35,6 +36,33 @@ double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list l)
         BoundedMean<double>::Builder().SetEpsilon(config->epsilon).Build().ValueOrDie();
   }
   Output result = mean->Result(a.begin(), a.end()).ValueOrDie();
+
+  return GetValue<double>(result);
+}
+
+// Bounded Sum
+double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list l) {
+  std::vector<double> a;
+
+  for (auto i : l) {
+    a.push_back(i.cast<double>());
+  }
+  std::unique_ptr<BoundedSum<double>> sum;
+  if (has_bounds) {
+    sum = BoundedSum<double>::Builder()
+      .SetEpsilon(config->epsilon)
+      .SetLower(config->lower)
+      .SetUpper(config->upper)
+      .Build()
+      .ValueOrDie();
+  } else {
+    sum =
+      BoundedSum<double>::Builder()
+      .SetEpsilon(config->epsilon)
+      .Build()
+      .ValueOrDie();
+  }
+  Output result = sum->Result(a.begin(), a.end()).ValueOrDie();
 
   return GetValue<double>(result);
 }

--- a/src/bindings/c/c_api.h
+++ b/src/bindings/c/c_api.h
@@ -29,6 +29,8 @@ extern void DeleteBoundedFunctionObject(BoundedFunctionHelperObject* config);
 // Bounded Mean
 extern double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::list a);
 
+extern double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list a);
+
 // Order statistics
 extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a,
                           double privacy_budget);

--- a/tests/algorithms/test_bounded_sum.py
+++ b/tests/algorithms/test_bounded_sum.py
@@ -1,0 +1,15 @@
+import pytest
+import pydp as dp
+
+
+class TestBoundedSum:
+    def test_c_api_sanity_check(self):
+        a = [1, 2, 3, 4]
+
+        sum_algorithm = dp.BoundedSum(1.0, 0, 10)
+        result = sum_algorithm.result(a)
+        # The result value is -16.0
+        # Google library tests make use of ZeroNoiseMechanism
+        # for more reasonable expected values, but we don't support
+        # setting Laplace mechanisms yet.
+        assert type(result) is float


### PR DESCRIPTION
## Description

Adds bindings for BoundedSum (through the C API).

Partial solution of issue #20 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Did you run `make test-all`?

Tests are still broken (see issue #126), but private_sum in carrots demo is now working.

## Checklist:

- [x] New Unit tests added
- [ ] Unit tests pass locally with my changes
