### PR TITLE
Fix Makefile syntax

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ export BROWSER_PYSCRIPT
 python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
 python_version_major := $(word 1,${python_version_full})
 
-ifeq ($(python_version_major), 2):
+ifeq ($(python_version_major), 2)
 	python_var := python3
 else
 	python_var := python


### PR DESCRIPTION
## Description

Here's a small fix of a syntax error in the Makefile.

Running make always produces this warning:
```
Makefile:20: extraneous text after 'ifeq' directive
```

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Run `make help` without this fix to see:
```
Makefile:20: extraneous text after 'ifeq' directive
```
as the first line of output.

With this fix the warning goes away :broom:
