### PR TITLE
Fix a namespace in logging.cpp

### DIFF
--- a/src/bindings/PyDP/base/logging.cpp
+++ b/src/bindings/PyDP/base/logging.cpp
@@ -20,7 +20,7 @@ class Logging_helper {
     return dpb::get_vlog_level();
   }
 
-  std::__cxx11::string get_log_directory() {
+  std::string get_log_directory() {
     return dpb::get_log_directory();
   }
 };


### PR DESCRIPTION
## Description

Hey,
This small change fixes #144 

I don't understand the whole story here but:
1. The google library uses `std::string` not `std::__cxx11::string`,
2. This is currently [the only place](https://github.com/OpenMined/PyDP/search?q=cxx11&unscoped_q=cxx11) in our codebase where `__cxx11` appears,
3. This part of PyDP is probably broken anyway (tests in `test_logging.py` have been failing for a while),
4. Removing `__cxx11` from here fixes the building process (issue #144).

## Type of change

Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Running `./build_PyDP.sh` on Ubuntu 20.04 ends with error and this change fixes that. Building the Docker image succeeds regardless of the change (base image is python:3.6-slim-buster).