### PR TITLE
Add bindings for BoundedStandardDeviation

### DIFF
--- a/src/bindings/BUILD
+++ b/src/bindings/BUILD
@@ -25,6 +25,7 @@ pybind_extension(
         "@google_dp//differential_privacy/algorithms:algorithm",
         "@google_dp//differential_privacy/algorithms:bounded-mean",
         "@google_dp//differential_privacy/algorithms:bounded-sum",
+        "@google_dp//differential_privacy/algorithms:bounded-standard-deviation",
         "@google_dp//differential_privacy/algorithms:count",
         "@google_dp//differential_privacy/algorithms:order-statistics",
         "@google_dp//differential_privacy/proto:data_cc_proto"

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -30,6 +30,14 @@ public:
   }
 };
 
+class BoundedStandardDeviationDummy : public Dummy {
+public:
+  using Dummy::Dummy;
+  double Result(py::list l) override {
+    return Result_BoundedStandardDeviation(obj, l);
+  }
+};
+
 void declareBoundedMean(py::module& m) {
   py::class_<BoundedMeanDummy> bld(m, "BoundedMean");
 
@@ -50,7 +58,18 @@ void declareBoundedSum(py::module& m) {
   cls.def("result", &BoundedSumDummy::Result);
 }
 
+void declareBoundedStandardDeviation(py::module& m) {
+  py::class_<BoundedStandardDeviationDummy> cls(m, "BoundedStandardDeviation");
+
+  cls.def(py::init<double, int, int>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  cls.def(py::init<double>(), py::return_value_policy::reference,
+          py::call_guard<pybind11::gil_scoped_release>());
+  cls.def("result", &BoundedStandardDeviationDummy::Result);
+}
+
 void init_algorithms_bounded_functions(py::module& m) {
   declareBoundedMean(m);
   declareBoundedSum(m);
+  declareBoundedStandardDeviation(m);
 }

--- a/src/bindings/c/c_api.cc
+++ b/src/bindings/c/c_api.cc
@@ -4,6 +4,7 @@
 
 #include "differential_privacy/algorithms/bounded-mean.h"
 #include "differential_privacy/algorithms/bounded-sum.h"
+#include "differential_privacy/algorithms/bounded-standard-deviation.h"
 
 #include "absl/random/distributions.h"
 #include "differential_privacy/algorithms/order-statistics.h"
@@ -63,6 +64,32 @@ double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list l) 
       .ValueOrDie();
   }
   Output result = sum->Result(a.begin(), a.end()).ValueOrDie();
+
+  return GetValue<double>(result);
+}
+
+double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config, pybind11::list l) {
+  std::vector<double> a;
+
+  for (auto i : l) {
+    a.push_back(i.cast<double>());
+  }
+  std::unique_ptr<BoundedStandardDeviation<double>> standard_deviation;
+
+  if (has_bounds) {
+    standard_deviation = BoundedStandardDeviation<double>::Builder()
+      .SetEpsilon(config->epsilon)
+      .SetLower(config->lower)
+      .SetUpper(config->upper)
+      .Build()
+      .ValueOrDie();
+  } else {
+    standard_deviation = BoundedStandardDeviation<double>::Builder()
+      .SetEpsilon(config->epsilon)
+      .Build()
+      .ValueOrDie();
+  }
+  Output result = standard_deviation->Result(a.begin(), a.end()).ValueOrDie();
 
   return GetValue<double>(result);
 }

--- a/src/bindings/c/c_api.h
+++ b/src/bindings/c/c_api.h
@@ -31,6 +31,8 @@ extern double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::
 
 extern double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list a);
 
+extern double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config, pybind11::list a);
+
 // Order statistics
 extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a,
                           double privacy_budget);

--- a/tests/algorithms/test_bounded_standard_deviation.py
+++ b/tests/algorithms/test_bounded_standard_deviation.py
@@ -3,8 +3,10 @@ import pydp as dp
 
 class TestBoundedStandardDeviation:
     def test_c_api(self):
-        a = [1, 5, 7, 9, 13]
-
-        bsd = dp.BoundedStandardDeviation(1.0, 0, 15)
-        result = bsd.result(a)
+        example_data = [1, 5, 7, 9, 13]
+        epsilon = 1.0
+        lower_bound, upper_bound = 0, 15
+        bsd = dp.BoundedStandardDeviation(epsilon, lower_bound, upper_bound)
+        result = bsd.result(example_data)
         assert type(result) is float
+        assert lower_bound <= result <= upper_bound

--- a/tests/algorithms/test_bounded_standard_deviation.py
+++ b/tests/algorithms/test_bounded_standard_deviation.py
@@ -1,0 +1,10 @@
+import pydp as dp
+
+
+class TestBoundedStandardDeviation:
+    def test_c_api(self):
+        a = [1, 5, 7, 9, 13]
+
+        bsd = dp.BoundedStandardDeviation(1.0, 0, 15)
+        result = bsd.result(a)
+        assert type(result) is float


### PR DESCRIPTION
## Description

Adds bindings for BoundedStandardDeviation (through the C API).

Partial(?) solution of issue #19 

## Type of change

Please mark options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Did you run `make test-all`?
Some tests are still failing. New test is not very useful, but for more strict tests we need to start setting noise to zero.

## Checklist:

- [x] New Unit tests added
- [ ] Unit tests pass locally with my changes
