### PR TITLE
Include "C API" files in clang-format check

### DIFF
--- a/.github/workflows/style_check.yml
+++ b/.github/workflows/style_check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Lint with clang-format
       run: |
         # lint files (all .cpp and .h files) inplace
-        find ./src/bindings/PyDP -iname *.hpp -o -iname *.cpp -iname *.h -iname *.cc | xargs clang-format -i -style='file'
+        find ./src/bindings/ -iname *.hpp -o -iname *.cpp -o -iname *.h -o -iname *.cc | xargs clang-format -i -style='file'
         # print changes
         git diff src
         # already well formated if 'git diff' doesn't output

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -23,7 +23,7 @@ class BoundedMeanDummy : public Dummy {
 };
 
 class BoundedSumDummy : public Dummy {
-public:
+ public:
   using Dummy::Dummy;
   double Result(py::list l) override {
     return Result_BoundedSum(obj, l);
@@ -31,7 +31,7 @@ public:
 };
 
 class BoundedStandardDeviationDummy : public Dummy {
-public:
+ public:
   using Dummy::Dummy;
   double Result(py::list l) override {
     return Result_BoundedStandardDeviation(obj, l);

--- a/src/bindings/PyDP/algorithms/rand.cpp
+++ b/src/bindings/PyDP/algorithms/rand.cpp
@@ -1,14 +1,14 @@
 // Provides bindings for rand
+#include "differential_privacy/algorithms/rand.h"
 #include "../pydp_lib/casting.hpp"
 #include "pybind11/pybind11.h"
-#include "differential_privacy/algorithms/rand.h"
 
 namespace py = pybind11;
 namespace dp = differential_privacy;
 
-void declareRandFunctions(py::module & m) {
-  m.def("UniformDouble",&dp::UniformDouble);
-  m.def("Geometric",&dp::Geometric);
+void declareRandFunctions(py::module& m) {
+  m.def("UniformDouble", &dp::UniformDouble);
+  m.def("Geometric", &dp::Geometric);
 }
 
 void init_algorithms_rand(py::module& m) {

--- a/src/bindings/PyDP/bindings.cpp
+++ b/src/bindings/PyDP/bindings.cpp
@@ -23,7 +23,7 @@ void init_algorithms_distributions(py::module &);
 void init_algorithms_order_statistics(py::module &);
 
 // rand
-void init_algorithms_rand(py::module&);
+void init_algorithms_rand(py::module &);
 
 // proto
 void init_proto(py::module &);

--- a/src/bindings/c/c_api.cc
+++ b/src/bindings/c/c_api.cc
@@ -3,8 +3,8 @@
 #include "differential_privacy/algorithms/algorithm.h"
 
 #include "differential_privacy/algorithms/bounded-mean.h"
-#include "differential_privacy/algorithms/bounded-sum.h"
 #include "differential_privacy/algorithms/bounded-standard-deviation.h"
+#include "differential_privacy/algorithms/bounded-sum.h"
 
 #include "absl/random/distributions.h"
 #include "differential_privacy/algorithms/order-statistics.h"
@@ -51,24 +51,22 @@ double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list l) 
   std::unique_ptr<BoundedSum<double>> sum;
   if (has_bounds) {
     sum = BoundedSum<double>::Builder()
-      .SetEpsilon(config->epsilon)
-      .SetLower(config->lower)
-      .SetUpper(config->upper)
-      .Build()
-      .ValueOrDie();
+              .SetEpsilon(config->epsilon)
+              .SetLower(config->lower)
+              .SetUpper(config->upper)
+              .Build()
+              .ValueOrDie();
   } else {
     sum =
-      BoundedSum<double>::Builder()
-      .SetEpsilon(config->epsilon)
-      .Build()
-      .ValueOrDie();
+        BoundedSum<double>::Builder().SetEpsilon(config->epsilon).Build().ValueOrDie();
   }
   Output result = sum->Result(a.begin(), a.end()).ValueOrDie();
 
   return GetValue<double>(result);
 }
 
-double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config, pybind11::list l) {
+double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config,
+                                       pybind11::list l) {
   std::vector<double> a;
 
   for (auto i : l) {
@@ -78,16 +76,16 @@ double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config, pybi
 
   if (has_bounds) {
     standard_deviation = BoundedStandardDeviation<double>::Builder()
-      .SetEpsilon(config->epsilon)
-      .SetLower(config->lower)
-      .SetUpper(config->upper)
-      .Build()
-      .ValueOrDie();
+                             .SetEpsilon(config->epsilon)
+                             .SetLower(config->lower)
+                             .SetUpper(config->upper)
+                             .Build()
+                             .ValueOrDie();
   } else {
     standard_deviation = BoundedStandardDeviation<double>::Builder()
-      .SetEpsilon(config->epsilon)
-      .Build()
-      .ValueOrDie();
+                             .SetEpsilon(config->epsilon)
+                             .Build()
+                             .ValueOrDie();
   }
   Output result = standard_deviation->Result(a.begin(), a.end()).ValueOrDie();
 

--- a/src/bindings/c/c_api.h
+++ b/src/bindings/c/c_api.h
@@ -31,7 +31,8 @@ extern double Result_BoundedMean(BoundedFunctionHelperObject* config, pybind11::
 
 extern double Result_BoundedSum(BoundedFunctionHelperObject* config, pybind11::list a);
 
-extern double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config, pybind11::list a);
+extern double Result_BoundedStandardDeviation(BoundedFunctionHelperObject* config,
+                                              pybind11::list a);
 
 // Order statistics
 extern int64_t Result_Max(BoundedFunctionHelperObject* config, pybind11::list a,


### PR DESCRIPTION
## Description

Apparently files in `src/bindings/c` are excluded from the style check and do not follow the formatting standard. Some other files avoided the check probably because of missing `-o` in the `find` command (details are in this PR style check results).

~This PR only fixes the style check (no files reformatted yet).~