### PR TITLE
Fix BoundedStandardDeviation test

### DIFF
--- a/tests/algorithms/test_bounded_standard_deviation.py
+++ b/tests/algorithms/test_bounded_standard_deviation.py
@@ -8,5 +8,5 @@ class TestBoundedStandardDeviation:
         lower_bound, upper_bound = 0, 15
         bsd = dp.BoundedStandardDeviation(epsilon, lower_bound, upper_bound)
         result = bsd.result(example_data)
-        assert type(result) is float
-        assert lower_bound <= result <= upper_bound
+        assert type(result) is float and result >= 0
+        assert result <= (upper_bound - lower_bound) / 2


### PR DESCRIPTION
## Description

The test I've recently written for BoundedStandardDeviation made zero sense mathematically :bug: There was an inequality satisfied only by accident.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
