### PR TITLE
Dockerfile now takes --build-arg PYTHON_VERSION={major}.{minor}

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+/third_party

--- a/contributing.md
+++ b/contributing.md
@@ -61,10 +61,16 @@ $ pip install dist/*.whl
 Dockerfile is added so users on all systems can get involved in development.
 Windows developers can start contributing with the help of Docker support.
 
-To build the image:
+To build the image with the default python version:
 
 ```
 $ docker build -t pydp:test .
+```
+
+To change the python version use the --build-arg parameter:
+
+```
+$ docker build --build-args PYTHON_VERSION=3.8 -t pydp:test .
 ```
 
 To run the image:


### PR DESCRIPTION
- added .dockerignore file
- cleaned up Dockerfile
- updated contributing.md with example

# Pull Request

## Description
I fixed the issues with incorrect versions of python during build in the Dockerfile and added parameters to allow versions to be configured by command line during building.

## Affected Dependencies
List any dependencies that are required for this change.

## Type of Change
Please mark options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation (non-breaking change which adds documentation)
- [x] Improvement (non-breaking change that improves the performance or reliability of existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How has this been tested?
I have built python 3.6, 3.7 and 3.8 containers on my local machine.

## Checklist
- [x] I did follow the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md)
- [x] I did follow the [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have added tests for my changes

## Additional Context
Please also include relevant motivation and context.
Issue was reported in slack.