### PR TITLE
Python Package Structure  fix #92

### DIFF
--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -48,7 +48,7 @@ class BoundedVarianceDummy : public Dummy {
 
 void declareBoundedMean(py::module& m) {
   py::class_<BoundedMeanDummy> bld(m, "BoundedMean");
-
+  bld.attr("__module__") = "pydp";
   bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def(py::init<double>(), py::return_value_policy::reference,
@@ -58,7 +58,7 @@ void declareBoundedMean(py::module& m) {
 
 void declareBoundedSum(py::module& m) {
   py::class_<BoundedSumDummy> cls(m, "BoundedSum");
-
+  cls.attr("__module__") = "pydp";
   cls.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   cls.def(py::init<double>(), py::return_value_policy::reference,
@@ -68,7 +68,7 @@ void declareBoundedSum(py::module& m) {
 
 void declareBoundedStandardDeviation(py::module& m) {
   py::class_<BoundedStandardDeviationDummy> cls(m, "BoundedStandardDeviation");
-
+  cls.attr("__module__") = "pydp";
   cls.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   cls.def(py::init<double>(), py::return_value_policy::reference,
@@ -78,7 +78,7 @@ void declareBoundedStandardDeviation(py::module& m) {
 
 void declareBoundedVariance(py::module& m) {
   py::class_<BoundedVarianceDummy> cls(m, "BoundedVariance");
-
+  cls.attr("__module__") = "pydp";
   cls.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   cls.def(py::init<double>(), py::return_value_policy::reference,

--- a/src/bindings/PyDP/algorithms/count.cpp
+++ b/src/bindings/PyDP/algorithms/count.cpp
@@ -14,8 +14,9 @@ template <typename T>
 void declareCount(py::module& m, string const& suffix) {
   using count_builder = typename dp::Count<T>::Builder;
 
-  py::class_<dp::Count<T>>(m, ("Count" + suffix).c_str())
-      .def(py::init([]() { return count_builder().Build().ValueOrDie(); }))
+  py::class_<dp::Count<T>> count(m, ("Count" + suffix).c_str());
+  count.attr("__module__") = "pydp";
+  count.def(py::init([]() { return count_builder().Build().ValueOrDie(); }))
       .def(py::init([](double epsilon) {
         return count_builder().SetEpsilon(epsilon).Build().ValueOrDie();
       }))

--- a/src/bindings/PyDP/algorithms/distributions.cpp
+++ b/src/bindings/PyDP/algorithms/distributions.cpp
@@ -9,8 +9,9 @@ namespace py = pybind11;
 namespace dpi = differential_privacy::internal;
 
 void declareLaplaceDistribution(py::module& m) {
-  py::class_<dpi::LaplaceDistribution>(m, "LaplaceDistribution")
-      .def(py::init<double>())
+  py::class_<dpi::LaplaceDistribution> laplace_dist(m, "LaplaceDistribution");
+  laplace_dist.attr("__module__") = "pydp";
+  laplace_dist.def(py::init<double>())
       .def("get_uniform_double", &dpi::LaplaceDistribution::GetUniformDouble)
       .def("sample",
            (double (dpi::LaplaceDistribution::*)()) & dpi::LaplaceDistribution::Sample)
@@ -21,8 +22,9 @@ void declareLaplaceDistribution(py::module& m) {
 }
 
 void declareGaussianDistribution(py::module& m) {
-  py::class_<dpi::GaussianDistribution>(m, "GaussianDistribution")
-      .def(py::init<double>())
+  py::class_<dpi::GaussianDistribution> gauss_dist(m, "GaussianDistribution");
+  gauss_dist.attr("__module__") = "pydp";
+  gauss_dist.def(py::init<double>())
       .def("sample", (double (dpi::GaussianDistribution::*)()) &
                          dpi::GaussianDistribution::Sample)
       .def("sample", (double (dpi::GaussianDistribution::*)(double)) &

--- a/src/bindings/PyDP/algorithms/order_statistics.cpp
+++ b/src/bindings/PyDP/algorithms/order_statistics.cpp
@@ -63,7 +63,7 @@ class PercentileDummy : public Dummy {
 
 void declareMax(py::module& m) {
   py::class_<MaxDummy> bld(m, "Max");
-
+  bld.attr("__module__") = "pydp";
   bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def(py::init<double>(), py::return_value_policy::reference,
@@ -73,7 +73,7 @@ void declareMax(py::module& m) {
 
 void declareMin(py::module& m) {
   py::class_<MinDummy> bld(m, "Min");
-
+  bld.attr("__module__") = "pydp";
   bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def(py::init<double>(), py::return_value_policy::reference,
@@ -83,7 +83,7 @@ void declareMin(py::module& m) {
 
 void declareMedian(py::module& m) {
   py::class_<MedianDummy> bld(m, "Median");
-
+  bld.attr("__module__") = "pydp";
   bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def(py::init<double>(), py::return_value_policy::reference,
@@ -93,7 +93,7 @@ void declareMedian(py::module& m) {
 
 void declarePercentile(py::module& m) {
   py::class_<PercentileDummy> bld(m, "Percentile");
-
+  bld.attr("__module__") = "pydp";
   bld.def(py::init<double, int, int>(), py::return_value_policy::reference,
           py::call_guard<pybind11::gil_scoped_release>());
   bld.def(py::init<double>(), py::return_value_policy::reference,

--- a/src/bindings/PyDP/algorithms/util.cpp
+++ b/src/bindings/PyDP/algorithms/util.cpp
@@ -10,7 +10,7 @@ namespace dp = differential_privacy;
 
 void init_algorithms_util(py::module& m) {
   py::module util = m.def_submodule("util", "Some Utility Functions");
-
+  util.attr("__module__") = "pydp";
   util.def("xor_strings", &dp::XorStrings);
   util.def("default_epsilon", &dp::DefaultEpsilon);
   util.def("get_next_power_of_two", &dp::GetNextPowerOfTwo);

--- a/src/bindings/PyDP/base/logging.cpp
+++ b/src/bindings/PyDP/base/logging.cpp
@@ -33,6 +33,7 @@ class Logging_helper {
 
 void init_base_logging(py::module& m) {
   py::class_<Logging_helper> obje(m, "Logging");
+  obje.attr("__module__") = "pydp";
   obje.def(py::init<const char*, const char*, int>());
 
   // cannot set these two properites it as set log_directory and v_log level is

--- a/src/bindings/PyDP/base/percentile.cpp
+++ b/src/bindings/PyDP/base/percentile.cpp
@@ -10,8 +10,9 @@ namespace dpb = differential_privacy::base;
 
 template <typename T>
 void declarePercentile(py::module& m, string const& suffix) {
-  py::class_<dpb::Percentile<T>>(m, ("Percentile" + suffix).c_str())
-      .def(py::init())
+  py::class_<dpb::Percentile<T>> percentile (m, ("Percentile" + suffix).c_str());
+  percentile.attr("__module__") = "pydp";
+  percentile.def(py::init())
       .def("add", &dpb::Percentile<T>::Add)
       .def("reset", &dpb::Percentile<T>::Reset)
       .def("serialize_to_proto", &dpb::Percentile<T>::SerializeToProto)

--- a/src/bindings/PyDP/base/percentile.cpp
+++ b/src/bindings/PyDP/base/percentile.cpp
@@ -10,7 +10,7 @@ namespace dpb = differential_privacy::base;
 
 template <typename T>
 void declarePercentile(py::module& m, string const& suffix) {
-  py::class_<dpb::Percentile<T>> percentile (m, ("Percentile" + suffix).c_str());
+  py::class_<dpb::Percentile<T>> percentile(m, ("Percentile" + suffix).c_str());
   percentile.attr("__module__") = "pydp";
   percentile.def(py::init())
       .def("add", &dpb::Percentile<T>::Add)

--- a/src/bindings/PyDP/base/status.cpp
+++ b/src/bindings/PyDP/base/status.cpp
@@ -44,7 +44,7 @@ void declareStatusOr2(py::module &m, string const &suffix) {
 void init_base_status(py::module &m) {
   // Creating the Status class
   py::class_<dpb::Status> status(m, "Status");
-
+  status.attr("__module__") = "pydp";
   // Status class (we can now build functions and enuums from this class)
   status.def(py::init<dpb::StatusCode &, std::string &>())
       .def("__repr__", &dpb::Status::ToString, "String representation of status")


### PR DESCRIPTION
## Description
Fixing python import having double `pydp` when we use `type`, #92 

## How has this been tested?
All tests should work as is. Only changes structuring. 
Ran case given in #92 to verify fix.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
