### PR TITLE
Fix some typos and grammatical errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 # PyDP
 
-In today's data-driven world, where data analytics is used by the Researchers or Data Scientists to create better models or innovative solutions for a better future! They often tend to handle sensitive or personal data, which brings in some privacy concerns. For example, sometimes, AI models can memorize details about the data they've trained on and could 'leak' these details later on. Differential privacy is a framework (using math) for measuring this leakage and reducing the possibility of it happening. 
+In today's data-driven world, data analytics is used by researchers or data scientists to create better models or innovative solutions for a better future. These models often tend to handle sensitive or personal data, which brings in some privacy concerns. For example, some AI models can memorize details about the data they've trained on and could leak these details later on. Differential privacy is a mathematical framework for measuring this privacy leakage and reducing the possibility of it happening. 
 
-This is where PyDP comes in. PyDP is a Python wrapper for Google's [Differential Privacy](https://github.com/google/differential-privacy) project. The library provides a set of ε-differentially private algorithms, which can be used to produce aggregate statistics over numeric data sets containing private or sensitive information. Thus, helping us achieve better privacy.
+This is where PyDP comes in. PyDP is a Python wrapper for Google's [Differential Privacy](https://github.com/google/differential-privacy) project. The library provides a set of ε-differentially private algorithms, which can be used to produce aggregate statistics over numeric data sets containing private or sensitive information. Thus, PyDP is helping us achieve better privacy.
 
 **Things to remember about PyDP :**
-- :rocket: Features Differentially Private Algorithmic functions to support carrots demo including: BoundedMean, BoundedSum, Max, Count Above, Percentile, Min, Median, etc.  
-- All the computation methods mentioned above, use Laplace noise only. (Other noise mechanisms will be added soon... :smiley:)
+- :rocket: Features differentially private algorithms including: BoundedMean, BoundedSum, Max, Count Above, Percentile, Min, Median, etc.  
+- All the computation methods mentioned above use Laplace noise only. (Other noise mechanisms will be added soon... :smiley:)
 - :fire: Currently supports Linux and OSX. (Windows coming real soon... :smiley:)
 - :star: Supports all the Python 3+ versions.
 
@@ -29,7 +29,7 @@ For usage via code explanation, refer to [Jupyer Notebook](https://github.com/Op
 
 A sample of usage can be found below:
 
-```
+```python
 import pydp as dp # imports the DP library
 
 # To calculate the Bounded Mean
@@ -55,7 +55,7 @@ x.result(input_data: list)
 Some of the good learning resources to get started with Python differential privacy (PyDP) project and understand the concepts behind it can be found [here](https://github.com/OpenMined/PyDP/blob/dev/resources.md).
 
 ## Join Us
-PyDP is part of the OpenMined community, come join the rapidly growing community of 7300+ on [Slack](http://slack.openmined.org/). The slack community is very friendly and great about quickly answering questions and getting your doubts cleared plus, it is a great place to interact with the fellow community member with similar interests such as yours.
+PyDP is part of the OpenMined community. Come join the rapidly growing community of 7300+ on [Slack](http://slack.openmined.org/). The slack community is very friendly and great about quickly answering questions and getting your doubts cleared. It is also a great place to interact with fellow community members who have similar interests.
 
 ## Start Contributing
 

--- a/examples/1.1 - Introductions to PyDP.ipynb
+++ b/examples/1.1 - Introductions to PyDP.ipynb
@@ -167,7 +167,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Taking Mean of all the entries in a normal fashion without Applying the DP library. This is the actual mean of all the records."
+    "Taking the mean of all the entries in a normal fashion without applying the DP library. This is the actual mean of all the records."
    ]
   },
   {
@@ -220,9 +220,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, the value of Private Mean varries compares to the Mean calculted using normal Statistical methods.\n",
+    "As you can see, the value of the private mean varies compared to the mean calculated using non-private statistical methods.\n",
     "\n",
-    "This difference in values refers to that privacy is actually preserved for individual records in it."
+    "This difference in value corresponds to the privacy that is actually preserved for individual records in it."
    ]
   },
   {
@@ -267,7 +267,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Counts number of animals who ate more than 'limit' carrots without Applying the DP library. This is the actual number of such animals."
+    "Counts number of animals who ate more than 'limit' carrots without applying the DP library. This is the actual number of such animals."
    ]
   },
   {
@@ -314,7 +314,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, the value of Private Count Above varries compares to the Count calculted using normal Statistical methods.\n",
+    "As you can see, the value of Private Count Above varies compared to the Count calculated using normal Statistical methods.\n",
     "\n",
     "This difference in values refers to that privacy is actually preserved for individual records in it."
    ]
@@ -388,7 +388,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, the value of Private Max varries compares to the Max calculted using normal Statistical methods.\n",
+    "As you can see, the value of Private Max varies compared to the Max calculated using normal Statistical methods.\n",
     "\n",
     "This difference in values refers to that privacy is actually preserved for individual records in it."
    ]

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ the animals as many carrots as they desire. The animals record how many carrots
 they have eaten per day. For this particular day, the number of carrots eaten
 can be seen in `animals_and_carrots.csv`.
 
-At the end of each day, Alex often asks aggregate question about how many
+At the end of each day, Alex often asks aggregate questions about how many
 carrots everyone ate. For example, he wants to know how many carrots are eaten
 each day, so he knows how many to order the next day. The animals are fearful
 that Alex will use the data against their best interest. For example, Alex could


### PR DESCRIPTION
Just fixing some typos and minor grammatical errors in:
- the main readme
- the carrot example readme
- the carrot example notebook