### PR TITLE
Added a dockerfile for easy running of examples.

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,18 @@
+# Pull base image
+ARG PYTHON_VERSION=3.7
+FROM python:${PYTHON_VERSION}-slim-buster
+ENV PROJECT_DIR="${HOME}/examples"
+# Update pip and setuptools and install pipenv
+RUN pip install --upgrade pip setuptools wheel && \
+    pip install pipenv
+WORKDIR ${PROJECT_DIR}
+COPY . .
+# This makes the pipenv's virtual environment in the project dir 
+ENV PIPENV_VENV_IN_PROJECT=true 
+RUN pipenv install python-dp pandas jupyter --skip-lock
+# This `activates` the virtual env
+ENV VIRTUAL_ENV=$PROJECT_DIR/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+EXPOSE 8899
+ENTRYPOINT ["jupyter", "notebook", "--ip=0.0.0.0", "--port=8899","--no-browser", "--allow-root"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,3 +40,10 @@ more than one row.
 ## How to Run
 
 ```python PyDP/example/carrots.py```
+
+### Docker alternative
+To run the examples in a container:
+1. `cd PyDP/examples`
+2. `docker build -t pydp-sandbox:local .`
+3. `docker run -p 8899:8899 pydp-sandbox:local`
+4. Open `displayed url` in a browser.


### PR DESCRIPTION
## Description
Following a slack conversation there was a desire for a simple way to run the PyDP examples. It's a minimal docker image with the example dependencies and jupyter installed. 

Summary added to readme:
### Docker alternative
To run the examples in a container:
1. `cd PyDP/examples`
2. `docker build -t pydp-sandbox:local .`
3. `docker run -p 8899:8899 pydp-sandbox:local`
4. Open `displayed url` in a browser. 

## Affected Dependencies
None.

## How has this been tested?
Tested on my local machine following the `examples/readme.md`

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
