### PR TITLE
Fixed typo for docker build in readme

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -104,7 +104,7 @@ $ docker build -t pydp:test .
 To change the python version use the --build-arg parameter:
 
 ```
-$ docker build --build-args PYTHON_VERSION=3.8 -t pydp:test .
+$ docker build --build-arg PYTHON_VERSION=3.8 -t pydp:test .
 ```
 
 To run the image:


### PR DESCRIPTION
## Description
I have faced an error while following the contributing guideline. The error was "unknown flag: --build-args". Then I realized it was a spelling mistake in the guideline. So, I removed the 's'  from the command.

## Affected Dependencies
N/A

## How has this been tested?
N/A

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
