### PR TITLE
Run clang-format from pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ format-style-python: ## format Python files code style in-place
 
 format-style-cpp: ## format C++ files code style in-place
 	@ find ./src/bindings/ -iname *.hpp -o -iname *.cpp -o -iname *.h -o -iname *.cc | \
-	xargs clang-format -i -style='file'
+	pipenv run xargs clang-format -i -style='file'
 
 check-style-python:
 	@ echo "\e[36mChecking Python code style.\e[0m" && \

--- a/Pipfile
+++ b/Pipfile
@@ -9,5 +9,6 @@ bumpversion = "==0.5.3"
 pytest = "*"
 black = "*"
 twine = "*"
+clang-format = "*"
 
 [packages]


### PR DESCRIPTION
## Description
This PR add clang-format as a Pip dependency and updates the Makefile to run  `clang-format` from the local pipenv instead of system `clang-format` installation.

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
Running `make format-style-cpp` does work and `pipenv run which clang-format` returns `$HOME/.virtualenvs/PyDP-0gi0zXcO/bin/clang-format`

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
