### PR TITLE
Run clang-format from the system installation instead of pipenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ format-style-python: ## format Python files code style in-place
 
 format-style-cpp: ## format C++ files code style in-place
 	@ find ./src/bindings/ -iname *.hpp -o -iname *.cpp -o -iname *.h -o -iname *.cc | \
-	pipenv run xargs clang-format -i -style='file'
+	xargs clang-format -i -style='file'
 
 check-style-python: ## check for Python code style in-place
 	@ echo "\e[36mChecking Python code style.\e[0m" && \

--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,6 @@ bumpversion = "==0.5.3"
 pytest = "*"
 black = "*"
 twine = "*"
-clang-format = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
 

--- a/prereqs_linux.sh
+++ b/prereqs_linux.sh
@@ -46,6 +46,12 @@ else
     rm bazel-2.1.0-installer-linux-x86_64.sh
 fi
 
+# clang-format
+if command -v clang-format &>/dev/null; then
+    echo "clang-format already installed"
+else
+    echo "installing clang-format"
+    sudo apt-get install clang-format
 
 # Downloading the Google DP library
 git submodule update --init --recursive

--- a/prereqs_linux.sh
+++ b/prereqs_linux.sh
@@ -52,6 +52,7 @@ if command -v clang-format &>/dev/null; then
 else
     echo "installing clang-format"
     sudo apt-get install clang-format
+fi
 
 # Downloading the Google DP library
 git submodule update --init --recursive

--- a/prereqs_mac.sh
+++ b/prereqs_mac.sh
@@ -28,6 +28,14 @@ else
     brew install bazelbuild/tap/bazel
 fi
 
+# clang-format
+if command -v clang-format &>/dev/null; then
+    echo "clang-format already installed"
+else
+    echo "installing clang-format"
+    brew install clang-format
+fi
+
 # pipenv
 echo "Checking for pipenv"
 if python3 -c "import pipenv" &> /dev/null; then


### PR DESCRIPTION
## Description
This PR removes clang-format as a Pip dependency and updates the Makefile to run clang-format from the system  clang-format installation.
Fixes #215 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
Running `make format-style-cpp` does work.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
