### PR TITLE
[WIP] Added a more compact name and type lookup.

### DIFF
--- a/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
+++ b/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
@@ -49,34 +49,17 @@ class AlgorithmBuilder {
         .ValueOrDie();
   }
 
+  std::map<std::type_index, std::string> type_to_name = {{typeid(double), "Double"},
+                                                         {typeid(int), "Int"}};
+  std::map<std::type_index, std::string> algorithm_to_name = {
+      {typeid(dp::BoundedMean<T>), "BoundedMean"},
+      {typeid(dp::BoundedSum<T>), "BoundedSum"},
+      {typeid(dp::BoundedStandardDeviation<T>), "BoundedStandardDeviation"},
+      {typeid(dp::BoundedVariance<T>), "BoundedVariance"}};
+
   std::string get_algorithm_name() {
     // Set the suffix string
-    std::string suffix = "";
-    // TODO: Change to mapping function
-    if (typeid(T) == typeid(int)) {
-      suffix = "Int";
-    } else if (typeid(T) == typeid(double)) {
-      suffix = "Double";
-    } else {
-      throw std::runtime_error("Binding error - Only int and double types supported");
-    }
-
-    // Set the algorithm name string
-    std::string name = "";
-    // TODO: Change to mapping function
-    if (typeid(Algorithm) == typeid(dp::BoundedMean<T>)) {
-      name = "BoundedMean";
-    } else if (typeid(Algorithm) == typeid(dp::BoundedSum<T>)) {
-      name = "BoundedSum";
-    } else if (typeid(Algorithm) == typeid(dp::BoundedStandardDeviation<T>)) {
-      name = "BoundedStandardDeviation";
-    } else if (typeid(Algorithm) == typeid(dp::BoundedVariance<T>)) {
-      name = "BoundedVariance";
-    } else {
-      throw std::runtime_error(std::string("Binding error - Unsupported algorithm: ") +
-                               std::string(typeid(Algorithm).name()));
-    }
-    return (name + suffix);
+    return (algorithm_to_name[typeid(Algorithm)] + type_to_name[typeid(T)]);
   }
 };
 


### PR DESCRIPTION
## Description
Following the same pattern proposed by @alejandrosame here is a possible compact version for looking up name and type.  Note it breaks with the bounded functions as it stamps out `BoundedMeanInt` and `BoundedMeanDouble` etc. But can be fixed if we adopt this approach.

@chinmayshah99 suggested that we make a numpy style api like #204 
"What would be great is mention the datatype of the list in another argument,"
```
x.result([1,2,3,4], 'int') 
```
How do we want to address this as I think it's best done/explored early. 
## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- All `test_count.py` tests pass.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
