### PR TITLE
added error handling in partial result

### DIFF
--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -46,6 +46,10 @@ void declareBoundedAlgorithm(py::module& m) {
   bld.def("privacy_budget_left",
           [](Algorithm& obj) { return obj.RemainingPrivacyBudget(); });
 
+  bld.def("add_entry", [](Algorithm& obj, T& v) {
+    obj.AddEntry(v);
+  });
+
   bld.def("add_entries", [](Algorithm& obj, std::vector<T>& v) {
     obj.AddEntries(v.begin(), v.end());
   });
@@ -56,21 +60,20 @@ void declareBoundedAlgorithm(py::module& m) {
     if (!result.ok()) {
       throw std::runtime_error(result.status().error_message());
     }
-
     return dp::GetValue<double>(result.ValueOrDie());
   });
 
   bld.def("partial_result", [](Algorithm& obj, double privacy_budget) {
+    if (privacy_budget > obj.RemainingPrivacyBudget()){
+      throw std::runtime_error("Privacy budget requeted exceeds set privacy budget");
+    }
     auto result = obj.PartialResult(privacy_budget);
 
     if (!result.ok()) {
       throw std::runtime_error(result.status().error_message());
     }
-
     return dp::GetValue<double>(result.ValueOrDie());
   });
-
-  bld.def_property_readonly("epsilon", [](Algorithm& obj) { return obj.GetEpsilon(); });
 
   bld.def("result", [](Algorithm& obj, std::vector<T>& v) {
     auto result = obj.Result(v.begin(), v.end());
@@ -78,8 +81,7 @@ void declareBoundedAlgorithm(py::module& m) {
     if (!result.ok()) {
       throw std::runtime_error(result.status().error_message());
     }
-
-    return dp::GetValue<T>(result.ValueOrDie());
+    return dp::GetValue<double>(result.ValueOrDie());
   });
 }
 


### PR DESCRIPTION
## Description
partial result was causing a crashi when the privacy budget exceeded privacy budget already available. added an error checking for same. 

## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
