### PR TITLE
pin sphinx version becuase of sphinx bug in 3.2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 python-dp
 sphinx-rtd-theme
+sphinx<=3.1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 python-dp
 sphinx-rtd-theme
-sphinx<=3.1.2
+sphinx<=3.1.2 # because of https://github.com/sphinx-doc/sphinx/issues/8074


### PR DESCRIPTION
## Description
Because of this bug, sphinx-doc/sphinx#8074, we can't use sphinx 3.2.0 to build docs for latest PyDP with docstrings. It results in 
```
Extension error:
Handler <function _process_docstring at 0x7f5a23643310> for event 'autodoc-process-docstring' threw an exception (exception: module, class, method, function, traceback, frame, or code object was expected, got instancemethod)
Makefile:56: recipe for target 'html' failed
make: *** [html] Error 2
```

To reproduce - inside PyDP (dev branch) and in a clean virtual environment, run:
```
pip install .
pip install sphinx-rtd-theme
cd docs
make html
```

Thus without restricting the version of Sphinx, in [docs/requirements.txt](docs/requirements.txt) we run the risk of install 3.2.0 and therefore building the docs will fail. Thus the fix in this PR restricts the version of Sphinx in [docs/requirements.txt](docs/requirements.txt) to be no greater than 3.1.2.

## Affected Dependencies
Sphinx

## How has this been tested?
In a new python environment with only the python-dp in the current dev branch installed, running:
```
cd docs
pip install -r requirements.txt
make html
```
succesfully builds the docs.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
