### PR TITLE
Update docs to reference new interface

### DIFF
--- a/docs/pydp.rst
+++ b/docs/pydp.rst
@@ -4,13 +4,36 @@ PyDP
 
 Algorithms
 ##########
-.. automodule:: pydp.algorithms.laplacian
-   :members: BoundedMean, BoundedSum, BoundedStandardDeviation, BoundedVariance, Max, Min, Median, Count, Percentile
+.. currentmodule:: pydp.algorithms.laplacian
+.. autoclass:: BoundedMean
+   :inherited-members: 
+
+.. autoclass::  BoundedSum
+   :inherited-members: 
+.. autoclass::  BoundedStandardDeviation
+   :inherited-members: 
+.. autoclass::  BoundedVariance
+   :inherited-members: 
+.. autoclass::  Max
+   :inherited-members: 
+.. autoclass::  Min
+   :inherited-members: 
+.. autoclass::  Median
+   :inherited-members: 
+.. autoclass::  Count
+   :inherited-members: 
+.. autoclass::  Percentile
+   :inherited-members: 
+
+
 
 Distributions
 #############
-.. automodule:: pydp.distributions
-   :members: GaussianDistribution, LaplaceDistribution
+.. currentmodule:: pydp.distributions
+.. autoclass::  GaussianDistribution
+   :members:
+.. autoclass::  LaplaceDistribution
+   :members:
 
 Util
 ##########

--- a/docs/pydp.rst
+++ b/docs/pydp.rst
@@ -1,8 +1,19 @@
+*********
 PyDP
 *********
 
-.. automodule:: pydp
-   :members: LaplaceDistribution, GeometricDistribution
+Algorithms
+##########
+.. automodule:: pydp.algorithms.laplacian
+   :members: BoundedMean, BoundedSum, BoundedStandardDeviation, BoundedVariance, Max, Min, Median, Count, Percentile
 
+Distributions
+#############
+.. automodule:: pydp.distributions
+   :members: GaussianDistribution, LaplaceDistribution
 
-       
+Util
+##########
+.. automodule:: pydp.util
+   :members: Geometric, UniformDouble, correlation, get_next_power_of_two, mean, order_statistics, qnorm, round_to_nearest_multiple, safe_add, safe_square, safe_subtract, standard_deviation, variance, vector_filter, vector_to_string, xor_strings
+   

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 python-dp
 sphinx-rtd-theme
-sphinx<=3.1.2 # because of https://github.com/sphinx-doc/sphinx/issues/8074
+sphinx>=3.2.1


### PR DESCRIPTION
## Description
- Updated the docs to reference the new python interface where needed.
- Updated sphinx to use 3.2.1 and 3.2.0 was broken and we pinned below that. Now 3.2.1 is out we can safely update it. 


## Affected Dependencies
Sphinx (just for the docs not a `python-dp` dependency) 
## How has this been tested?
- All docs build and render locally when following the instructions in `contributing.md`
## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
