### PR TITLE
Allow int64 as dtype

### DIFF
--- a/pydp/algorithms/_algorithm.py
+++ b/pydp/algorithms/_algorithm.py
@@ -27,6 +27,8 @@ class MetaAlgorithm:
             return "Int"
         elif dtype == "float":
             return "Double"
+        elif dtype == "long long":
+            return "LongLong"
         else:
             raise RuntimeError("dtype: {} is not supported".format(dtype))
 

--- a/pydp/algorithms/_algorithm.py
+++ b/pydp/algorithms/_algorithm.py
@@ -25,10 +25,10 @@ class MetaAlgorithm:
     def __map_dtype_str(dtype: str):
         if dtype == "int":
             return "Int"
+        elif dtype == "int64":
+            return "Int64"
         elif dtype == "float":
             return "Double"
-        elif dtype == "long long":
-            return "LongLong"
         else:
             raise RuntimeError("dtype: {} is not supported".format(dtype))
 
@@ -116,7 +116,7 @@ class MetaAlgorithm:
     def serialize(self):
         """
         Serializes summary data of current entries into Summary proto. This allows results from distributed aggregation to be recorded and later merged.
-        
+
         Returns empty summary for algorithms for which serialize is unimplemented.
         """
         return self.__algorithm.serialize()

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -27,18 +27,18 @@ void declareBoundedAlgorithm(py::module& m) {
 
 void init_algorithms_bounded_functions(py::module& m) {
   declareBoundedAlgorithm<int, dp::BoundedMean<int>>(m);
+  declareBoundedAlgorithm<int64_t, dp::BoundedMean<int64_t>>(m);
   declareBoundedAlgorithm<double, dp::BoundedMean<double>>(m);
-  declareBoundedAlgorithm<long long, dp::BoundedMean<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedSum<int>>(m);
+  declareBoundedAlgorithm<int64_t, dp::BoundedSum<int64_t>>(m);
   declareBoundedAlgorithm<double, dp::BoundedSum<double>>(m);
-  declareBoundedAlgorithm<long long, dp::BoundedSum<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedStandardDeviation<int>>(m);
+  declareBoundedAlgorithm<int64_t, dp::BoundedStandardDeviation<int64_t>>(m);
   declareBoundedAlgorithm<double, dp::BoundedStandardDeviation<double>>(m);
-  declareBoundedAlgorithm<long long, dp::BoundedStandardDeviation<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedVariance<int>>(m);
+  declareBoundedAlgorithm<int64_t, dp::BoundedVariance<int64_t>>(m);
   declareBoundedAlgorithm<double, dp::BoundedVariance<double>>(m);
-  declareBoundedAlgorithm<long long, dp::BoundedVariance<long long>>(m);
 }

--- a/src/bindings/PyDP/algorithms/bounded_functions.cpp
+++ b/src/bindings/PyDP/algorithms/bounded_functions.cpp
@@ -28,13 +28,17 @@ void declareBoundedAlgorithm(py::module& m) {
 void init_algorithms_bounded_functions(py::module& m) {
   declareBoundedAlgorithm<int, dp::BoundedMean<int>>(m);
   declareBoundedAlgorithm<double, dp::BoundedMean<double>>(m);
+  declareBoundedAlgorithm<long long, dp::BoundedMean<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedSum<int>>(m);
   declareBoundedAlgorithm<double, dp::BoundedSum<double>>(m);
+  declareBoundedAlgorithm<long long, dp::BoundedSum<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedStandardDeviation<int>>(m);
   declareBoundedAlgorithm<double, dp::BoundedStandardDeviation<double>>(m);
+  declareBoundedAlgorithm<long long, dp::BoundedStandardDeviation<long long>>(m);
 
   declareBoundedAlgorithm<int, dp::BoundedVariance<int>>(m);
   declareBoundedAlgorithm<double, dp::BoundedVariance<double>>(m);
+  declareBoundedAlgorithm<long long, dp::BoundedVariance<long long>>(m);
 }

--- a/src/bindings/PyDP/algorithms/count.cpp
+++ b/src/bindings/PyDP/algorithms/count.cpp
@@ -21,4 +21,5 @@ void declareAlgorithm(py::module& m) {
 void init_algorithms_count(py::module& m) {
   declareAlgorithm<int, dp::Count<int>>(m);
   declareAlgorithm<double, dp::Count<double>>(m);
+  declareAlgorithm<long long, dp::Count<long long>>(m);
 }

--- a/src/bindings/PyDP/algorithms/count.cpp
+++ b/src/bindings/PyDP/algorithms/count.cpp
@@ -20,6 +20,6 @@ void declareAlgorithm(py::module& m) {
 
 void init_algorithms_count(py::module& m) {
   declareAlgorithm<int, dp::Count<int>>(m);
+  declareAlgorithm<int64_t, dp::Count<int64_t>>(m);
   declareAlgorithm<double, dp::Count<double>>(m);
-  declareAlgorithm<long long, dp::Count<long long>>(m);
 }

--- a/src/bindings/PyDP/algorithms/order_statistics.cpp
+++ b/src/bindings/PyDP/algorithms/order_statistics.cpp
@@ -21,13 +21,17 @@ void declareOrderStat(py::module& m) {
 void init_algorithms_order_statistics(py::module& m) {
   declareOrderStat<int64_t, dp::continuous::Max<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Max<double>>(m);
+  declareOrderStat<long long, dp::continuous::Max<long long>>(m);
 
   declareOrderStat<int64_t, dp::continuous::Min<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Min<double>>(m);
+  declareOrderStat<long long, dp::continuous::Min<long long>>(m);
 
   declareOrderStat<int64_t, dp::continuous::Median<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Median<double>>(m);
+  declareOrderStat<long long, dp::continuous::Median<long long>>(m);
 
   declareOrderStat<int64_t, dp::continuous::Percentile<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Percentile<double>>(m);
+  declareOrderStat<long long, dp::continuous::Percentile<long long>>(m);
 }

--- a/src/bindings/PyDP/algorithms/order_statistics.cpp
+++ b/src/bindings/PyDP/algorithms/order_statistics.cpp
@@ -19,19 +19,19 @@ void declareOrderStat(py::module& m) {
 }
 
 void init_algorithms_order_statistics(py::module& m) {
+  declareOrderStat<int, dp::continuous::Max<int>>(m);
   declareOrderStat<int64_t, dp::continuous::Max<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Max<double>>(m);
-  declareOrderStat<long long, dp::continuous::Max<long long>>(m);
 
+  declareOrderStat<int, dp::continuous::Min<int>>(m);
   declareOrderStat<int64_t, dp::continuous::Min<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Min<double>>(m);
-  declareOrderStat<long long, dp::continuous::Min<long long>>(m);
 
+  declareOrderStat<int, dp::continuous::Median<int>>(m);
   declareOrderStat<int64_t, dp::continuous::Median<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Median<double>>(m);
-  declareOrderStat<long long, dp::continuous::Median<long long>>(m);
 
+  declareOrderStat<int, dp::continuous::Percentile<int>>(m);
   declareOrderStat<int64_t, dp::continuous::Percentile<int64_t>>(m);
   declareOrderStat<double, dp::continuous::Percentile<double>>(m);
-  declareOrderStat<long long, dp::continuous::Percentile<long long>>(m);
 }

--- a/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
+++ b/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
@@ -92,8 +92,8 @@ class AlgorithmBuilder {
   std::map<std::type_index, std::string> type_to_name = {
       {typeid(double), "Double"},
       {typeid(int), "Int"},
-      {typeid(int64_t), "Int"},
-      {typeid(long long), "LongLong"}};
+      {typeid(int64_t), "Int64"},
+  };
   std::map<std::type_index, std::string> algorithm_to_name = {
       {typeid(dp::BoundedMean<T>), "BoundedMean"},
       {typeid(dp::BoundedSum<T>), "BoundedSum"},

--- a/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
+++ b/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
@@ -90,7 +90,10 @@ class AlgorithmBuilder {
   }
 
   std::map<std::type_index, std::string> type_to_name = {
-      {typeid(double), "Double"}, {typeid(int), "Int"}, {typeid(int64_t), "Int"}};
+      {typeid(double), "Double"},
+      {typeid(int), "Int"},
+      {typeid(int64_t), "Int"},
+      {typeid(long long), "LongLong"}};
   std::map<std::type_index, std::string> algorithm_to_name = {
       {typeid(dp::BoundedMean<T>), "BoundedMean"},
       {typeid(dp::BoundedSum<T>), "BoundedSum"},

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -25,9 +25,9 @@ def test_bounded_mean():
     # assert isinstance(bm2.quick_result([1.5, 2, 2.5]), float)
 
 
-def test_bounded_mean_long_long():
+def test_bounded_mean_int64():
     example_list = [5] * 100000000
-    x = BoundedMean(1.0, 0, 10, dtype="long long")
+    x = BoundedMean(1.0, 0, 10, dtype="int64")
     for _ in range(5):
         x.add_entries(example_list)
 

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -1,6 +1,10 @@
 import pytest
 from pydp.algorithms.laplacian import BoundedMean
 
+expect_near = lambda expected, actual, tol: (
+    expected + tol >= actual and expected - tol <= actual
+)
+
 
 def test_python_api():
     a = [2, 4, 6, 8]
@@ -19,6 +23,15 @@ def test_bounded_mean():
     bm2 = BoundedMean(epsilon=3.4, dtype="int")
     assert isinstance(bm2, BoundedMean)
     # assert isinstance(bm2.quick_result([1.5, 2, 2.5]), float)
+
+
+def test_bounded_mean_long_long():
+    example_list = [5] * 100000000
+    x = BoundedMean(1.0, 0, 10, dtype="long long")
+    for _ in range(5):
+        x.add_entries(example_list)
+
+    assert expect_near(5.0, x.result(), 0.1)
 
 
 # TODO: port this test

--- a/tests/algorithms/test_count.py
+++ b/tests/algorithms/test_count.py
@@ -2,7 +2,7 @@ import pytest
 from pydp.algorithms.laplacian import Count
 
 
-@pytest.mark.parametrize("dtype_in", ["int", "float", "long long"])
+@pytest.mark.parametrize("dtype_in", ["int", "int64", "float"])
 class TestPercentile:
     def test_basic(self, dtype_in):
         c = [1, 2, 3, 4, 2, 3]

--- a/tests/algorithms/test_count.py
+++ b/tests/algorithms/test_count.py
@@ -2,7 +2,7 @@ import pytest
 from pydp.algorithms.laplacian import Count
 
 
-@pytest.mark.parametrize("dtype_in", ["int", "float"])
+@pytest.mark.parametrize("dtype_in", ["int", "float", "long long"])
 class TestPercentile:
     def test_basic(self, dtype_in):
         c = [1, 2, 3, 4, 2, 3]


### PR DESCRIPTION
## Description
This PR fixes #174. In that issue @chinmayshah99 exposes an issue when trying to compute the mean of a big list, where an overflow causes the result to become 0. By introducing `long long` as an underlying type, we enable the correct computation of these big lists.  

## Affected Dependencies
No dependencies affected.

## How has this been tested?
- Added a new test case `test_bounded_mean_long_long`.
- `make test` executes successfully.
- After compiling and installing on a Raspberry Pi 4 (OS Raspbian [Buster 10] 32 bit), `make test` also executes successfully.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
