### PR TITLE
adds Docker build on PR 

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -1,0 +1,38 @@
+on:
+    push:
+      branches:
+      - dev
+    pull_request:
+      types: [opened, synchronize, reopened]
+
+name: Build and Test Docker Image
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+    env:
+      IMAGE: openmined/pydp
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+     
+      - name: Show python version and build image name  
+        id: build_name
+        run: |
+          python -c "import sys; print(sys.version)"
+          echo "::set-output name=image_name::${IMAGE}-${GITHUB_REF##*/}-${{matrix.python-version}}"
+
+      - name: Build images
+        run: docker build -t ${{steps.build_name.outputs.image_name}} --build-arg PYTHON_VERSION=${{matrix.python-version}} -f Dockerfile .
+
+   
+

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 setuptools = "*"
 bumpversion = "==0.5.3"
 pytest = "*"
-black = "*"
+black = "==19.10b0"
 twine = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"


### PR DESCRIPTION
## Description
Closes #260, As requested by @chinmayshah99  every PR to dev branch triggers a docker build to check if the PR breaks the docker image or not.

## Affected Dependencies
black version is hardcoded to 19.10b0

## How has this been tested?
- Checked on test PR

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
