### PR TITLE
Fix core crashes due to bound params

### DIFF
--- a/pydp/algorithms/_algorithm.py
+++ b/pydp/algorithms/_algorithm.py
@@ -40,7 +40,7 @@ class MetaAlgorithm:
         elif dtype == "float":
             return "Double"
         else:
-            raise RuntimeError("dtype: {} is not supported".format(dtype))
+            raise ValueError("dtype '{}' is not supported.".format(dtype))
 
     @property
     def epsilon(self) -> float:

--- a/pydp/algorithms/_algorithm.py
+++ b/pydp/algorithms/_algorithm.py
@@ -1,3 +1,5 @@
+import math
+
 from .._pydp import _algorithms
 
 from typing import Union, List
@@ -7,11 +9,14 @@ class MetaAlgorithm:
     def __init__(self, **kwargs):
         dtype = kwargs.pop("dtype")
 
-        # Delete bound params if they are not set to avoid  conflicts with builder
-        if "lower_bound" in kwargs and kwargs["lower_bound"] is None:
-            kwargs.pop("lower_bound")
-        if "upper_bound" in kwargs and kwargs["upper_bound"] is None:
-            kwargs.pop("upper_bound")
+        for arg_name in ["lower_bound", "upper_bound"]:
+            if arg_name in kwargs:
+                if kwargs[arg_name] is None:
+                    # Delete bound params if they are not set to avoid conflicts with builder
+                    kwargs.pop(arg_name)
+                else:
+                    # If they are set, check for edge cases
+                    self.__check_input(name=arg_name, value=kwargs[arg_name])
 
         binded_class = self.__class__.__name__ + self.__map_dtype_str(dtype)
         class_ = getattr(_algorithms, binded_class)
@@ -20,6 +25,13 @@ class MetaAlgorithm:
         self.__algorithm = class_(**kwargs)
         self._l0_sensitivity = kwargs.get("l0_sensitivity", "Not set")
         self._linf_sensitivity = kwargs.get("linf_sensitivity", "Not set")
+
+    @staticmethod
+    def __check_input(name: str, value: float):
+        if math.isnan(value) or math.isinf(value):
+            raise ValueError(
+                "invalid value '{}' for paramater '{}'.".format(value, name)
+            )
 
     @staticmethod
     def __map_dtype_str(dtype: str):
@@ -114,7 +126,7 @@ class MetaAlgorithm:
     def serialize(self):
         """
         Serializes summary data of current entries into Summary proto. This allows results from distributed aggregation to be recorded and later merged.
-        
+
         Returns empty summary for algorithms for which serialize is unimplemented.
         """
         return self.__algorithm.serialize()

--- a/tests/algorithms/test_algorithm.py
+++ b/tests/algorithms/test_algorithm.py
@@ -1,0 +1,42 @@
+import pytest
+from pydp.algorithms.laplacian import BoundedMean
+
+
+class TestInitParams:
+    def test_lower_bound_NaN(self):
+        with pytest.raises(ValueError):
+            mean = BoundedMean(
+                1.0, lower_bound=float("NaN"), upper_bound=10.0, dtype="float"
+            )
+
+    def test_upper_bound_NaN(self):
+        with pytest.raises(ValueError):
+            count = BoundedMean(
+                1.0, lower_bound=0.0, upper_bound=float("NaN"), dtype="float"
+            )
+
+    @pytest.mark.parametrize("lower_bound", ["-inf", "inf"])
+    def test_lower_bound_inf(self, lower_bound):
+        with pytest.raises(ValueError):
+            mean = BoundedMean(
+                1.0, lower_bound=float(lower_bound), upper_bound=10.0, dtype="float"
+            )
+
+    @pytest.mark.parametrize("upper_bound", ["-inf", "inf"])
+    def test_upper_bound_inf(self, upper_bound):
+        with pytest.raises(ValueError):
+            count = BoundedMean(
+                1.0, lower_bound=0.0, upper_bound=float(upper_bound), dtype="float"
+            )
+
+    @pytest.mark.parametrize(
+        "bounds", [("-inf", "-inf"), ("-inf", "inf"), ("inf", "inf"), ("inf", "-inf")]
+    )
+    def test_setting_inf_bounds(self, bounds):
+        with pytest.raises(ValueError):
+            count = BoundedMean(
+                1.0,
+                lower_bound=float(bounds[0]),
+                upper_bound=float(bounds[1]),
+                dtype="float",
+            )


### PR DESCRIPTION
## Description
Fixes #268. Given that the underlying C++ code does not accept NaN values and complains that "inf" values are too high, the approach followed by this was to simply raise ValueError exceptions when bound params are set to "NaN", "-inf" or "inf".

## Affected Dependencies
No dependencies changed.

## How has this been tested?
- Introduced new tests to cover this case.
- `make test` runs successfully.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
