### PR TITLE
Improve makefile actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include .env # Read .env file
 
-.PHONY: clean clean-test clean-pyc clean-build docs help
+.PHONY: build clean clean-test clean-pyc clean-build docs help
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -106,5 +106,5 @@ dist: clean ## builds source and wheel package
 	pipenv run python setup.py bdist_wheel
 	ls -l dist
 
-install: clean ## install the package to the active Python's site-packages
-	pipenv run python setup.py install
+install: dist ## install the package to the active Python's site-packages
+	pipenv run pip install --upgrade --force-reinstall dist/*.whl


### PR DESCRIPTION
## Description
While working on fixing #268 and adding new tests, I noticed that the current Makefile `build` and `install` actions were failing. This PR updates the Makefile for a smoother dev experience. These issues are never raised during CI testing because we always make fresh installations. 

## Affected Dependencies
No dependencies changed.

## How has this been tested?
I executed the changed actions manually:
- `make build` now can run multiple times even when `build_PyDP.sh` is not updated.
- `make install` now properly reinstalls PyDP package in the current pipenv environment.
- `make install` changes do not brake `make test` action.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
