### PR TITLE
Fixed runtime crash due to result()

### DIFF
--- a/pydp/algorithms/_algorithm.py
+++ b/pydp/algorithms/_algorithm.py
@@ -66,12 +66,16 @@ class MetaAlgorithm:
     def add_entries(self, data: List[Union[int, float]]) -> None:
         """
         Adds multiple inputs to the algorithm.
+
+        Note: If the data exceeds the overflow limit of storage, the current list passed is not added.
         """
         return self.__algorithm.add_entries(data)
 
     def add_entry(self, value: Union[int, float]) -> None:
         """
         Adds one input to the algorithm.
+
+        Note: If the data exceeds the overflow limit of storage, the current data passed is not added.
         """
         return self.__algorithm.add_entry(value)
 
@@ -80,6 +84,8 @@ class MetaAlgorithm:
         Runs the algorithm on the input using the epsilon parameter provided in the constructor and returns output.
 
         Consumes 100% of the privacy budget.
+        
+        Note: It resets the privacy budget first.
         """
         return self.__algorithm.result(data)
 
@@ -97,6 +103,10 @@ class MetaAlgorithm:
 
         `noise_interval_level` provides the confidence level of the noise confidence interval, which may be included in the algorithm output.
         """
+        if self.privacy_budget_left() == 0:
+            raise RuntimeError(
+                "Privacy Budget left is already 0, you can't do any more operations"
+            )
 
         if privacy_budget is None:
             return self.__algorithm.partial_result()

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -32,6 +32,14 @@ def test_serialize_merge():
     assert 3 <= bm2.result() <= 7
 
 
+def test_result_crash():
+    bm1 = BoundedMean(1, 1, 10)
+    bm1.add_entries([1 for i in range(100)])
+    bm1.result()
+    with pytest.raises(RuntimeError):
+        bm1.result()
+
+
 # TODO: port this test
 #
 # TYPED_TEST(BoundedMeanTest, BasicTest) {


### PR DESCRIPTION
## Description
Earlier when we called result() successive time, after the budget left was zero, the python run-time use to crash. 

Now, this raises a run-time warning if such a case arises. 

Fixes #263 

## How has this been tested?
- added additional test. 

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests
