### PR TITLE
added l0 and linf for count

### DIFF
--- a/pydp/algorithms/laplacian/_count.py
+++ b/pydp/algorithms/laplacian/_count.py
@@ -1,5 +1,7 @@
 from .._algorithm import MetaAlgorithm
 
+from typing import Union
+
 
 class Count(MetaAlgorithm):
     """
@@ -7,5 +9,16 @@ class Count(MetaAlgorithm):
     TODO
     """
 
-    def __init__(self, epsilon: float = 1.0, dtype: str = "int"):
-        super().__init__(epsilon=epsilon, dtype=dtype)
+    def __init__(
+        self,
+        epsilon: float = 1.0,
+        l0_sensitivity: int = 1,
+        linf_sensitivity: int = 1,
+        dtype: str = "int",
+    ):
+        super().__init__(
+            epsilon=epsilon,
+            l0_sensitivity=l0_sensitivity,
+            linf_sensitivity=linf_sensitivity,
+            dtype=dtype,
+        )

--- a/tests/algorithms/test_count.py
+++ b/tests/algorithms/test_count.py
@@ -67,6 +67,21 @@ class TestCountDataTypes:
         assert isinstance(res, int)
 
 
+@pytest.mark.parametrize("dtype_in", ["int", "float"])
+class TestCount:
+    def test_basic(self, dtype_in):
+        n = 100
+        c = [1 for _ in range(100)]
+        count = Count(epsilon=1, dtype=dtype_in)
+        assert n - 10 < count.quick_result(c) < n + 10
+
+    def test_l0_linf(self, dtype_in):
+        n = 100
+        c = [1 for _ in range(100)]
+        count = Count(epsilon=1, l0_sensitivity=1, linf_sensitivity=1, dtype=dtype_in)
+        assert n - 10 < count.quick_result(c) < n + 10
+
+
 # TODO: port the following tests
 #
 # TEST(CountTest, MergeTest)


### PR DESCRIPTION
## Description

Fixes #276 
Added l0 and linf as arguments that can be taken underneath Count().



## How has this been tested?
- added more tests

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
