### PR TITLE
Fix Geometric Distribution test ratio

### DIFF
--- a/src/bindings/PyDP/algorithms/distributions.cpp
+++ b/src/bindings/PyDP/algorithms/distributions.cpp
@@ -48,7 +48,6 @@ void declareGaussianDistribution(py::module &m) {
                              R"pbdoc(Returns stddev)pbdoc");
 }
 
-/*
 void declareGeometricDistribution(py::module &m) {
   py::class_<dpi::GeometricDistribution> geometric_dist(m, "GeometricDistribution");
   geometric_dist.attr("__module__") = "pydp";
@@ -70,9 +69,9 @@ before the first success where the success probability is as defined above. lamb
           the maximum int64_t, which means that users should be careful around the edges
           of their distribution)pbdoc";
 }
-*/
+
 void init_algorithms_distributions(py::module &m) {
   declareLaplaceDistribution(m);
   declareGaussianDistribution(m);
-  // declareGeometricDistribution(m);
+  declareGeometricDistribution(m);
 }

--- a/tests/algorithms/test_distributions.py
+++ b/tests/algorithms/test_distributions.py
@@ -2,7 +2,7 @@ import pytest
 from pydp.distributions import (
     LaplaceDistribution,
     GaussianDistribution,
-    # GeometricDistribution,
+    GeometricDistribution,
 )
 import pydp as dp
 import math

--- a/tests/algorithms/test_distributions.py
+++ b/tests/algorithms/test_distributions.py
@@ -112,8 +112,6 @@ class TestGaussianDistributionDataTypes:
 
 class TestGeometricDistribution:
     def test_ratios(self):
-        from collections import Counter
-
         p = 1e-2
         dist = GeometricDistribution(lambda_=-1.0 * math.log(1 - p))
         counts = [0] * 51

--- a/tests/algorithms/test_distributions.py
+++ b/tests/algorithms/test_distributions.py
@@ -111,19 +111,17 @@ class TestGaussianDistributionDataTypes:
 
 
 class TestGeometricDistribution:
-    @pytest.mark.skip(reason="This test should pass, see comments")
     def test_ratios(self):
-        """
-        This test fails. It's a replica of
-         https://github.com/google/differential-privacy/blob/9923ad4ee1b84a7002085e50345fcc05f2b21bcb/cc/algorithms/distributions_test.cc#L208 and should pass.
-        """
         from collections import Counter
 
         p = 1e-2
         dist = GeometricDistribution(lambda_=-1.0 * math.log(1 - p))
-        samples = [dist.sample() for _ in range(k_num_geometric_samples)]
-        counts = list(Counter([s for s in samples if s < 51]).values())
-        ratios = [c_i / c_j for c_i, c_j in zip(counts[:-1], counts[1:])]
+        counts = [0] * 51
+        for i in range(k_num_geometric_samples):
+            sample = dist.sample()
+            if sample < len(counts):
+                counts[sample] += 1
+        ratios = [c_j / c_i for c_i, c_j in zip(counts[:-1], counts[1:])]
 
         assert expect_near(p, dp.util.mean(ratios), p / 1e-2)
 


### PR DESCRIPTION
## Description
This PR fixes the issue of #213 .which involves the test ]ratios of Geometric Distribution did not pass. The main issue involves `Counter`, which stores the value of the frequency in the form of key-value pairs, and then sort them based on the counts. On the other hand, in the [original test file of Google DP](https://github.com/google/differential-privacy/blob/main/cc/algorithms/distributions_test.cc), the create an array of 0s with a length of 51. This preserved the indexes of the array instead of sorting it based on the highest occurrence of the sample.

## Affected Dependencies
No dependencies were affected.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
The changes made in the `test_distributions.py`.
- Provide instructions so we can reproduce.
Assuming the required environment is already set up, the test can be reproduced by running `pytest test_distributions.py -k "test_ratios` in the `/tests/algorithms` directory
- List any relevant details for your test configuration.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
