### PR TITLE
Added installation code for black in the docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN wget ${BAZEL_DOWNLOAD_URL}/${BAZEL_VERSION}/${BAZEL_INSTALLER} && \
 RUN pip install --upgrade pip setuptools wheel && \
     pip install pipenv
 
+# Install black
+RUN pip install black
+
 # Change working dir
 WORKDIR ${PROJECT_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,7 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install pipenv
 
 # Check for python version and install black
-
-RUN if [ ${PYTHON_VERSION} != 3.5* ]; then pip install black; fi
-
-# RUN v="$(python3 -c "print(__import__('sys').version_info[2])")" && \
-# if [ $[v] != 5 ]; then pip install black; fi
-
+RUN if [[ ${PYTHON_VERSION} >= 3.6 ]]; then pip install black; fi
 
 # Change working dir
 WORKDIR ${PROJECT_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN wget ${BAZEL_DOWNLOAD_URL}/${BAZEL_VERSION}/${BAZEL_INSTALLER} && \
 RUN pip install --upgrade pip setuptools wheel && \
     pip install pipenv
 
-# Install black
-RUN pip install black
+# Check for python version and install black
+RUN if [ ${PYTHON_VERSION} != 3.5 ]; then pip install black; fi
 
 # Change working dir
 WORKDIR ${PROJECT_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,11 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install pipenv
 
 # Check for python version and install black
-# RUN if [ ${PYTHON_VERSION} != 3.5 ]; then pip install black; fi
-RUN v="$(python3 -c "print(__import__('sys').version_info[2])")" && \
-if [ $[v] != 5 ]; then pip install black; fi
+
+RUN if [ ${PYTHON_VERSION} != 3.5* ]; then pip install black; fi
+
+# RUN v="$(python3 -c "print(__import__('sys').version_info[2])")" && \
+# if [ $[v] != 5 ]; then pip install black; fi
 
 
 # Change working dir

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,10 @@ RUN pip install --upgrade pip setuptools wheel && \
     pip install pipenv
 
 # Check for python version and install black
-RUN if [ ${PYTHON_VERSION} != 3.5 ]; then pip install black; fi
+# RUN if [ ${PYTHON_VERSION} != 3.5 ]; then pip install black; fi
+RUN v="$(python3 -c "print(__import__('sys').version_info[2])")" && \
+if [ $[v] != 5 ]; then pip install black; fi
+
 
 # Change working dir
 WORKDIR ${PROJECT_DIR}

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ verify_ssl = true
 setuptools = "*"
 bumpversion = "==0.5.3"
 pytest = "*"
-black = "==19.10b0"
 twine = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 setuptools = "*"
 bumpversion = "==0.5.3"
 pytest = "*"
-black = {version = "19.10b0", makers = "python_version >= 3.6"}
+black "==19.10b0"; python_version >= 3.6
 twine = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 setuptools = "*"
 bumpversion = "==0.5.3"
 pytest = "*"
-black "==19.10b0"; python_version >= 3.6
+black = "==19.10b0"
 twine = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"
@@ -15,3 +15,4 @@ gcovr = "*"
 coverage = "*"
 
 [packages]
+

--- a/Pipfile
+++ b/Pipfile
@@ -15,4 +15,3 @@ gcovr = "*"
 coverage = "*"
 
 [packages]
-

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 setuptools = "*"
 bumpversion = "==0.5.3"
 pytest = "*"
+black = {version = "19.10b0", makers = "python_version >= 3.6"}
 twine = "*"
 sphinx = "*"
 sphinx-rtd-theme = "*"


### PR DESCRIPTION
## Description
Blac program was not being installed while building the docker image. I had to be installed manually via pip. Changes have been made in the docker file to install black while building the docker image.

## Affected Dependencies
None

## How has this been tested?
The changes can be seen if the docker image is built as mentioned:
```$ docker build -t pydp:test .```
```$ docker run --rm -it pydp:test```
```$ make test```

It gives an error "the command black could not be found within PATH or Pipfile's [scripts]."
![Screenshot from 2020-11-07 12-05-01](https://user-images.githubusercontent.com/35634697/98444765-8b5e5600-2139-11eb-9162-598c55daa9ad.png)

After making the changes in the docker file, the error is resolved.

## Checklist
- [Yes] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [Yes] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [Yes] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [Yes] My changes are covered by tests
