### PR TITLE
Partial fix to py35 test cases failing

### DIFF
--- a/examples/laplace_demo/laplace.ipynb
+++ b/examples/laplace_demo/laplace.ipynb
@@ -296,7 +296,7 @@
     "    return 1 / (2 * b) * np.exp(-np.abs(x - μ) / b)\n",
     "\n",
     "def plot_laplace(x, μ, b):\n",
-    "    plt.plot(x, laplace(x, μ, b), label=f\"μ={μ}, b={b}\")"
+    "    plt.plot(x, laplace(x, μ, b), label=\"μ={}, b={}\".format(μ, b))"
    ]
   },
   {
@@ -448,7 +448,7 @@
     "plt.plot(x, dist1, label=\"distribution 1\")\n",
     "plt.plot(x, dist2, label=\"distribution 2\")\n",
     "plt.axvline(x=reported_value, c='black', dashes=(1,2), label=\"reported value\")\n",
-    "plt.legend();"
+    "plt.legend()"
    ]
   },
   {


### PR DESCRIPTION
## Description
py35 does not support formatted string, which is causing our test cases to break. Small fix for that. 


## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
