### PR TITLE
Fix Windows PyPi build GitHub Action

### DIFF
--- a/.github/workflows/pypipublish_windows.yml
+++ b/.github/workflows/pypipublish_windows.yml
@@ -24,7 +24,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install setuptools wheel twine auditwheel
     - name: Setup msbuild
-      uses: microsoft/setup-msbuild@v1.0.0
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Setup Bazel
       uses: abhinavsingh/setup-bazel@v3
     - name: Build PyDP

--- a/.github/workflows/pypipublish_windows.yml
+++ b/.github/workflows/pypipublish_windows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/pypipublish_windows.yml
+++ b/.github/workflows/pypipublish_windows.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
## Description
Fix setting up `msbuild` for Github Action `release` trigger by changing `setup-msbuild` version to 1.0.2; this was mentioned in issue #347. 

## Affected Dependencies
-

## How has this been tested?
I've tested this by publishing a release in my forked version of PyDP. In the logs mentioned in the issue, `msbuild` failed to build in GitHub Action. In my version of my forked version of the release, GitHub Action was able to set up the `msbuild`.

## Checklist
- [x] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [x] My changes are covered by tests
