### PR TITLE
Added argument names for delta/eps in GaussianMechanism.__init__

### DIFF
--- a/src/bindings/PyDP/mechanisms/mechanism.cpp
+++ b/src/bindings/PyDP/mechanisms/mechanism.cpp
@@ -121,9 +121,6 @@ class LaplaceMechanismBinder {
                return build(epsilon, sensitivity);
              }),
              py::arg("epsilon"), py::arg("sensitivity") = 1.0)
-        .def("get_uniform_double", &dp::LaplaceMechanism::GetUniformDouble)
-        // .def("deserialize", &dp::LaplaceMechanism::Deserialize)
-        // .def("serialize", &dp::LaplaceMechanism::Serialize)
         .def_property_readonly("sensitivity", &dp::LaplaceMechanism::GetSensitivity,
                                "The L1 sensitivity of the query.")
         .def_property_readonly("diversity", &dp::LaplaceMechanism::GetDiversity,
@@ -154,10 +151,9 @@ class GaussianMechanismBinder {
     gaus_mech.attr("__module__") = "pydp";
     gaus_mech
         .def(py::init([](double epsilon, double delta, double l2_sensitivity) {
-          return build(epsilon, delta, l2_sensitivity);
-        }))
-        // .def("deserialize", &dp::GaussianMechanism::Deserialize)
-        // .def("serialize", &dp::GaussianMechanism::Serialize)
+               return build(epsilon, delta, l2_sensitivity);
+             }),
+             py::arg("epsilon"), py::arg("delta"), py::arg("sensitivity") = 1.0)
         .def_property_readonly("delta", &dp::GaussianMechanism::GetDelta,
                                "The 𝛿 of the Gaussian mechanism.")
         .def_property_readonly(

--- a/tests/algorithms/test_numerical_mechanisms.py
+++ b/tests/algorithms/test_numerical_mechanisms.py
@@ -27,9 +27,6 @@ def test_basic():
     obj = num_mech.LaplaceMechanism(epsilon, sensitivity)
     assert num_mech_methods.issubset(set(dir(obj)))
     assert {
-        # "deserialize",
-        # "serialize",
-        "get_uniform_double",
         "memory_used",
         "sensitivity",
         "diversity",
@@ -37,8 +34,6 @@ def test_basic():
     obj = num_mech.GaussianMechanism(epsilon, delta, sensitivity)
     assert num_mech_methods.issubset(set(dir(obj)))
     assert {
-        # "deserialize",
-        # "serialize",
         "memory_used",
         "l2_sensitivity",
         "std",


### PR DESCRIPTION
Along the way small polishing were done
1.Removed commented code
2.Removed `GetUniformDouble` (which is not needed to be exposed)