### PR TITLE
Update to the latest version of Google building block library

### DIFF
--- a/prereqs_linux.sh
+++ b/prereqs_linux.sh
@@ -60,7 +60,7 @@ git submodule update --init --recursive
 
 
 # checkout out to particular commit
-cd third_party/differential-privacy && git checkout 4b02b94aae5a720f44e7b2b9806959388f8b6675 && \
+cd third_party/differential-privacy && git checkout bf0abf446b2f9d625a824bf14a7e3a6b6ac2a3e4 && \
 cd -
 # renaming workspace.bazel to workspace
 mv third_party/differential-privacy/cc/WORKSPACE.bazel third_party/differential-privacy/cc/WORKSPACE

--- a/src/bindings/PyDP/mechanisms/mechanism.cpp
+++ b/src/bindings/PyDP/mechanisms/mechanism.cpp
@@ -34,15 +34,6 @@ py::class_<dp::NumericalMechanism>& DefPyAddNoise(
                      py::arg("result"));
 }
 
-//template <typename T>
-//py::class_<dp::NumericalMechanism>& DefPyAddNoise(
-//    py::class_<dp::NumericalMechanism>& pyclass) {
-//  using FunctorType = T (dp::NumericalMechanism::*)(T);
-//  return pyclass.def("add_noise",
-//                     static_cast<FunctorType>(&dp::NumericalMechanism::AddNoise),
-//                     py::arg("result"));
-//}
-
 template <typename T, typename U>
 std::unique_ptr<T> downcast_unique_ptr(std::unique_ptr<U> u_ptr) {
   static_assert(std::is_base_of<U, T>::value, "Illegal downcast.");

--- a/src/bindings/PyDP/mechanisms/mechanism.cpp
+++ b/src/bindings/PyDP/mechanisms/mechanism.cpp
@@ -34,14 +34,14 @@ py::class_<dp::NumericalMechanism>& DefPyAddNoise(
                      py::arg("result"));
 }
 
-template <typename T, typename U>
-py::class_<dp::NumericalMechanism>& DefPyAddNoise(
-    py::class_<dp::NumericalMechanism>& pyclass) {
-  using FunctorType = T (dp::NumericalMechanism::*)(T, U);
-  return pyclass.def("add_noise",
-                     static_cast<FunctorType>(&dp::NumericalMechanism::AddNoise),
-                     py::arg("result"), py::arg("privacy_budget"));
-}
+//template <typename T>
+//py::class_<dp::NumericalMechanism>& DefPyAddNoise(
+//    py::class_<dp::NumericalMechanism>& pyclass) {
+//  using FunctorType = T (dp::NumericalMechanism::*)(T);
+//  return pyclass.def("add_noise",
+//                     static_cast<FunctorType>(&dp::NumericalMechanism::AddNoise),
+//                     py::arg("result"));
+//}
 
 template <typename T, typename U>
 std::unique_ptr<T> downcast_unique_ptr(std::unique_ptr<U> u_ptr) {
@@ -58,9 +58,6 @@ class NumericalMechanismBinder {
         Base class for all (Ɛ, 𝛿)-differenially private additive noise numerical mechanisms.
       )pbdoc");
     numerical_mech.attr("__module__") = "pydp";
-    DefPyAddNoise<int, double>(numerical_mech);
-    DefPyAddNoise<int64_t, double>(numerical_mech);
-    DefPyAddNoise<double, double>(numerical_mech);
     DefPyAddNoise<int>(numerical_mech);
     DefPyAddNoise<int64_t>(numerical_mech);
     DefPyAddNoise<double>(numerical_mech);
@@ -73,13 +70,12 @@ class NumericalMechanismBinder {
         .def("memory_used", &dp::NumericalMechanism::MemoryUsed)
         .def(
             "noise_confidence_interval",
-            [](dp::NumericalMechanism& self, double cl, double pb,
+            [](dp::NumericalMechanism& self, double cl,
                double nr) -> dp::ConfidenceInterval {
-              auto result = self.NoiseConfidenceInterval(cl, pb, nr);
+              auto result = self.NoiseConfidenceInterval(cl, nr);
               return result.ValueOrDie();
             },
-            py::arg("confidence_level"), py::arg("privacy_budget"),
-            py::arg("noised_result"),
+            py::arg("confidence_level"), py::arg("noised_result"),
             R"pbdoc(
               Returns the confidence interval of the specified confidence level of the
               noise that AddNoise() would add with the specified privacy budget.

--- a/tests/algorithms/test_numerical_mechanisms.py
+++ b/tests/algorithms/test_numerical_mechanisms.py
@@ -47,16 +47,12 @@ def test_laplace_mechanism():
     value = 0
     value = laplace.add_noise(value)
     assert type(value) is int
-    value = laplace.add_noise(value, 0.1)
-    assert type(value) is int
     value = 0.0
     value = laplace.add_noise(value)
     assert type(value) is float
-    value = laplace.add_noise(value, 0.1)
-    assert type(value) is float
     conf_level = 0.5
     priv_budg = 0.1
-    interval = laplace.noise_confidence_interval(0.5, 0.1, value)
+    interval = laplace.noise_confidence_interval(0.5, value)
     assert type(interval) is num_mech.ConfidenceInterval
     bound = laplace.diversity * np.log(1 - conf_level) / priv_budg
     lower_bound, upper_bound = value - bound, value + bound
@@ -71,16 +67,12 @@ def test_gaussian_mechanism():
     value = 0
     value = gaussian.add_noise(value)
     assert type(value) is int
-    value = gaussian.add_noise(value, 0.1)
-    assert type(value) is int
     value = 0.0
     value = gaussian.add_noise(value)
     assert type(value) is float
-    value = gaussian.add_noise(value, 0.1)
-    assert type(value) is float
     conf_level = 0.5
     priv_budg = 0.1
-    interval = gaussian.noise_confidence_interval(0.5, 0.1, value)
+    interval = gaussian.noise_confidence_interval(0.5, value)
     local_gaussian = num_mech.GaussianMechanism(
         priv_budg * epsilon, priv_budg * delta, l2_sensitivity
     )


### PR DESCRIPTION
Privacy budget parameter was removed from `add_noise` and `noise_confidence_interval`