### PR TITLE
Downgrade Ubuntu to 18.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 12
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Building on Ubuntu was introduced recently on [PR](https://github.com/OpenMined/PyDP/pull/431). On Ubuntu 20.04  _pydo.so depends on C++ runtime of version 3.4.26 ( i.e. GLIBCXX_3.4.26 ). The problem is that on many machines it's not available. 

This is a temproral solution to return back to 18.04.