### PR TITLE
Revert "Downgrade Ubuntu to 18.04"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       max-parallel: 12
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [3.7, 3.8, 3.9, "3.10"]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Reverts OpenMined/PyDP#448
reverting as ubuntu 18..04 build is not supported due to g++ dependency. 