### PR TITLE
Update broken link to google dp library in introduction.rst

### DIFF
--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -117,7 +117,7 @@ SOME OTHER LIBRARIES FOR DP
 
 * `OpenDp  <https://github.com/opendifferentialprivacy>`_ by Harvard University and Microsoft
 * `Diffprivlib <https://github.com/IBM/differential-privacy-library>`_  by IBM
-* Google’s Differential Privacy `Library <https://github.com/IBM/differential-privacy-library>`_ .
+* Google’s Differential Privacy `Library <https://github.com/google/differential-privacy>`_ .
 
 DIFFERENTIAL PRIVACY IN USE
 


### PR DESCRIPTION
## Description
The link was wrong. It pointed to the IBM DP Library instead of the Google one. I changed the link in the file `introduction.rst`

## Affected Dependencies
None

## How has this been tested?
Checked if the link works in my fork.

## Checklist
- [X] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [X] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [X] My changes are covered by tests