### PR TITLE
update README about BoundedMean function

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,14 @@ import pydp as dp
 from pydp.algorithms.laplacian import BoundedMean
 
 # Calculate the Bounded Mean
-# Structure: `BoundedMean(epsilon: double, lower: int, upper: int)`
+# Basic Structure: `BoundedMean(epsilon: float, lower_bound: Union[int, float, None], upper_bound: Union[int, float, None])`
 # `epsilon`: a Double, between 0 and 1, denoting the privacy threshold,
 #            measures the acceptable loss of privacy (with 0 meaning no loss is acceptable)
-# `lower` and `upper`: Integers, representing lower and upper bounds, respectively
-x = BoundedMean(0.6, 1, 10)
+x = BoundedMean(epsilon=0.6, lower_bound=1, upper_bound=10)
 
 # If the lower and upper bounds are not specified,
 # PyDP automatically calculates these bounds
-# x = BoundedMean(epsilon: double)
+# x = BoundedMean(epsilon: float)
 x = BoundedMean(0.6)
 
 # Calculate the result

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -61,15 +61,14 @@ Example: calculate the Bounded Mean
     from pydp.algorithms.laplacian import BoundedMean
 
     # Calculate the Bounded Mean
-    # Structure: `BoundedMean(epsilon: double, lower: int, upper: int)`
+    # Basic Structure: `BoundedMean(epsilon: float, lower_bound: Union[int, float, None], upper_bound: Union[int, float, None])`
     # `epsilon`: a Double, between 0 and 1, denoting the privacy threshold,
     #            measures the acceptable loss of privacy (with 0 meaning no loss is acceptable)
-    # `lower` and `upper`: Integers, representing lower and upper bounds, respectively
-    x = BoundedMean(0.6, 1, 10)
+    x = BoundedMean(epsilon=0.6, lower_bound=1, upper_bound=10)
 
     # If the lower and upper bounds are not specified,
     # PyDP automatically calculates these bounds
-    # x = BoundedMean(epsilon: double)
+    # x = BoundedMean(epsilon: float)
     x = BoundedMean(0.6)
 
     # Calculate the result


### PR DESCRIPTION
## Description
What is written in README.md file is old. So I updated it.
First of all, the execution of `BoundedMean(0.6, 1, 10)` has an error, because the arguments of BoundedMean function are `epsilon: float = 1.0, delta: float = 0, lower_bound: Union[int, float, None] = None, upper_bound: Union[int, float, None] = None, l0_sensitivity: int = 1, linf_sensitivity: int = 1, dtype: str = "int"` in order. So the second argument of `BoundedMean(0.6, 1, 10)` is incompatible to `delta`, which should be float type not integer type. 

Also the type of epsilon should be float not double, and modify some names of arguments like from `lower` to `lower_bound`. 

## Affected Dependencies
None.
