### PR TITLE
added support for python 3.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,5 @@ docs/_generate/*
 *.gcov
 coverage_report/*
 !coverage_report/index.html
+
+.python-version

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,8 +12,8 @@ http_archive(
 http_archive(
     name = "pybind11",
     build_file = "@pybind11_bazel//:pybind11.BUILD",
-    strip_prefix = "pybind11-2.6.2",
-    urls = ["https://github.com/pybind/pybind11/archive/v2.6.2.zip"],
+    strip_prefix = "pybind11-2.11.1",
+    urls = ["https://github.com/pybind/pybind11/archive/v2.11.1.zip"],
 )
 
 load("@pybind11_bazel//:python_configure.bzl", "python_configure")


### PR DESCRIPTION
## Description
Added support for python 3.11.
There were some change in C API for in the latest version of python which were not reflected in the pybind11. upgrading that has fixed it. Context- https://github.com/pybind/pybind11/discussions/4333


## Affected Dependencies
List any dependencies that are required for this change.

## How has this been tested?
- Describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- List any relevant details for your test configuration.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
