### PR TITLE
Build wheel with Manylinux

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,20 @@ jobs:
             ./bazel-cache
           key: ${{ runner.os }}-bazel-${{ hashFiles('WORKSPACE') }}
 
-      - name: Build Google DP Unix
-        if: runner.os != 'Windows'
+      - name: Build Google DP and wheel on Linux
+        if: runner.os == 'Linux'
+        timeout-minutes: 20
+        run: |
+          pip install cibuildwheel
+          # Set for which Python version to build. 
+          py_version=${matrix.python-version//.}          
+          EXPORT CIBW_BUILD=cp${py_version}-manylinux_x86_64
+          # Build wheel
+          echo "Building ${CIBW_BUILD} wheel" 
+          python -m cibuildwheel --output-dir dist .      
+
+      - name: Build Google DP Mac
+        if: runner.os == 'macOS'
         timeout-minutes: 20
         run: |
           PYTHONHOME=$(which python)
@@ -114,13 +126,13 @@ jobs:
         run: |
           poetry install
 
-      - name: Build PyDP macOS
+      - name: Build PyDP macOS wheel
         if: runner.os == 'macOS'
         run: |
           poetry run python setup.py build bdist_wheel --plat-name macosx_10_14_x86_64
 
-      - name: Build PyDP Linux / Windows
-        if: runner.os != 'macOS'
+      - name: Build PyDP Windows wheel
+        if: runner.os == 'Windows'
         run: |
           poetry run python setup.py build bdist_wheel
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,8 +67,9 @@ jobs:
         timeout-minutes: 20
         run: |
           pip install cibuildwheel
+          export CIBW_PLATFORM=linux
           # Set for which Python version to build. 
-          py_version=${matrix.python-version//.}          
+          py_version=${matrix.python-version//.}  # 3.11 -> 311     
           EXPORT CIBW_BUILD=cp${py_version}-manylinux_x86_64
           # Build wheel
           echo "Building ${CIBW_BUILD} wheel" 

--- a/build_PyDP_linux.sh
+++ b/build_PyDP_linux.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This script differs from build_PyDP.sh by installing bazel first (if needed).
+BAZELISK_VERSION=v1.8.1
+BAZELISK_BINARY=bazelisk-linux-amd64
+BAZELISK_DOWNLOAD_URL=https://github.com/bazelbuild/bazelisk/releases/download/
+
+if command -v bazel &>/dev/null; then
+    echo "Bazel already installed"
+else
+  python -m wget "${BAZELISK_DOWNLOAD_URL}/${BAZELISK_VERSION}/${BAZELISK_BINARY}"
+  chmod +x ${BAZELISK_BINARY}
+  mkdir bazel_dir
+  echo mv ${BAZELISK_BINARY} bazel_dir/bazel
+  mv ${BAZELISK_BINARY} bazel_dir/bazel
+  export PATH="$PATH:`pwd`/bazel_dir"
+fi
+
+./build_PyDP.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
+[build-system]
+requires = [
+    "setuptools",
+    "wget"
+]
+
 [tool.poetry]
 name        = "pydp"
 version     = "1.1.4"
@@ -34,7 +40,3 @@ sphinx           = "*"
 sphinx-rtd-theme = "*"
 twine            = "*"
 wheel            = "*"
-
-[build-system]
-requires      = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ WORKING_DIR = os.getcwd()
 
 class Build(build_ext):
     """Customized setuptools build command - builds protos on build."""
+
     def run(self):
         if platform.system() != "Linux":
             # For Windows and Mac setup.py is not used for wheel build but the
@@ -38,6 +39,7 @@ class Build(build_ext):
         os.system(f"cp {pydp_lib} {destination_dir}")
 
         build_ext.run(self)
+
 
 class BinaryDistribution(Distribution):
     """This class is needed in order to create OS specific wheels."""
@@ -68,9 +70,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
     ],
-    cmdclass={
-        'build_ext': Build
-    },
+    cmdclass={"build_ext": Build},
     description="Python API for Google's Differential Privacy library",
     distclass=BinaryDistribution,
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class Build(build_ext):
         os.system("./build_PyDP_linux.sh")
 
         # Copy _pydp.so to cibuildwheel directory.
-        pydp_lib = "cp src/pydp/_pydp.so"
+        pydp_lib = "src/pydp/_pydp.so"
         version_str = f"{sys.version_info.major}{sys.version_info.minor}"
         destination_dir = f"build/lib.linux-x86_64-cpython-{version_str}/pydp"
         os.system(f"cp {pydp_lib} {destination_dir}")


### PR DESCRIPTION
This PR implements wheel build with Manylinux for Linux.

## Why is it needed?

When a Linux binary is built , it is linked against the standard libraries (libc, libstdc++ etc) of versions that are present on the built machine. Those libraries are forward compatible, namely it's possible to run the binary on machines which have standard libraries newer than ones against which this binary was built. But it's not **backward** compatible, i.e. the binary might fail on the machines with older libraries with errors like `[usr/lib/libstdc++.so.6: version GLIBCXX_3.4.29 not found]`.

Currently since PyDP is built on Ubuntu 22, it fails to run on many older machines. We can choose Ubuntu 20, but there will be still problems with older machines.

## What is the solution?
The common solution for Python packages which have C++ parts are built C++ with [Manylinux](https://github.com/pypa/manylinux) docker images. Those are Docker images which contain old enough standard libraries, which improves compatibility.

For building [cibuildwheel](https://github.com/pypa/cibuildwheel) is used. This libraries manages build in Docker with Manylinux images.

**Note:** many common Python libs (e.g. Numpy, Matplolib) use cibuildwheel. [Here](https://github.com/pypa/cibuildwheel#working-examples)) are some other examples.

## What in this PR
It contains extending publish workflow with build on manylinux for Linux platform. Other platforms are not changed.
Namely it contains

1. Introducing `build_PyDP_linux.sh` which installs bazel and  run `build_PyDP.sh`.
2. Extending `setup.py` to call `build_PyDP_linux.sh` for Linux.
3. Updating `publish.yml` to use cibuildwheel on Linux