### PR TITLE
Raise ValueError/NotImplementedError instead of a generic RuntimeError based on DP error code

### DIFF
--- a/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
+++ b/src/bindings/PyDP/pydp_lib/algorithm_builder.hpp
@@ -11,6 +11,7 @@
 #include "algorithms/numerical-mechanisms.h"
 #include "algorithms/order-statistics.h"
 #include "proto/summary.pb.h"
+#include "status_errors.hpp"
 
 namespace dp = differential_privacy;
 namespace py = pybind11;
@@ -87,7 +88,7 @@ class AlgorithmBuilder {
 
     absl::StatusOr<std::unique_ptr<Algorithm>> obj = builder.Build();
     if (!obj.ok()) {
-      throw std::runtime_error(obj.status().ToString());
+      ThrowFromStatus(obj.status());
     }
 
     return std::move(obj.value());
@@ -176,7 +177,7 @@ class AlgorithmBuilder {
       auto result = pythis.Result(v.begin(), v.end());
 
       if (!result.ok()) {
-        throw std::runtime_error(result.status().ToString());
+        ThrowFromStatus(result.status());
       }
       if constexpr ((should_return_T<T, Algorithm>()))
         return dp::GetValue<T>(result.value());
@@ -190,7 +191,7 @@ class AlgorithmBuilder {
       auto result = pythis.PartialResult();
 
       if (!result.ok()) {
-        throw std::runtime_error(result.status().ToString());
+        ThrowFromStatus(result.status());
       }
 
       if constexpr ((should_return_T<T, Algorithm>()))
@@ -205,7 +206,7 @@ class AlgorithmBuilder {
       auto result = pythis.PartialResult(privacy_budget);
 
       if (!result.ok()) {
-        throw std::runtime_error(result.status().ToString());
+        ThrowFromStatus(result.status());
       }
 
       if constexpr ((should_return_T<T, Algorithm>()))
@@ -220,7 +221,7 @@ class AlgorithmBuilder {
       auto result = pythis.PartialResult(noise_interval_level);
 
       if (!result.ok()) {
-        throw std::runtime_error(result.status().ToString());
+        ThrowFromStatus(result.status());
       }
       if constexpr ((should_return_T<T, Algorithm>()))
         return dp::GetValue<T>(result.value());
@@ -238,7 +239,7 @@ class AlgorithmBuilder {
     pyself.def("merge", [](Algorithm& pythis, const dp::Summary& summary) {
       auto status = pythis.Merge(summary);
       if (!status.ok()) {
-        throw std::runtime_error(status.ToString());
+        ThrowFromStatus(status);
       }
     });
 

--- a/src/bindings/PyDP/pydp_lib/status_errors.hpp
+++ b/src/bindings/PyDP/pydp_lib/status_errors.hpp
@@ -1,0 +1,44 @@
+#ifndef PYDP_LIB_STATUS_ERRORS_H_
+#define PYDP_LIB_STATUS_ERRORS_H_
+
+#include <pybind11/pybind11.h>
+
+#include <string>
+
+#include "absl/status/status.h"
+
+namespace py = pybind11;
+
+namespace differential_privacy {
+namespace python {
+
+// Raises a Python exception for a non-OK absl::Status coming back from the DP
+// library, picking the exception type based on the status code instead of
+// collapsing every failure into a generic RuntimeError.
+//
+// This lets callers distinguish, for example, a bad argument they passed in
+// (ValueError) from a method that simply isn't implemented for a given
+// algorithm (NotImplementedError), the same way they would for any other
+// Python API. Status codes that don't have an obviously better fit (Internal,
+// FailedPrecondition, etc.) keep raising RuntimeError, which was already the
+// behavior for every code before this.
+//
+// `status` is expected to be non-OK; callers should check status.ok() (or
+// statusor.ok()) first.
+inline void ThrowFromStatus(const absl::Status& status) {
+  const std::string message = status.ToString();
+  switch (status.code()) {
+    case absl::StatusCode::kInvalidArgument:
+      throw py::value_error(message);
+    case absl::StatusCode::kUnimplemented:
+      PyErr_SetString(PyExc_NotImplementedError, message.c_str());
+      throw py::error_already_set();
+    default:
+      throw std::runtime_error(message);
+  }
+}
+
+}  // namespace python
+}  // namespace differential_privacy
+
+#endif  // PYDP_LIB_STATUS_ERRORS_H_

--- a/tests/algorithms/test_bounded_mean.py
+++ b/tests/algorithms/test_bounded_mean.py
@@ -86,10 +86,14 @@ def test_serialize_merge():
 
 
 def test_result_crash():
+    # Calling result()/partial_result() a second time trips the DP library's
+    # "InvalidArgument" check (an algorithm can only produce results once for
+    # a given epsilon/delta budget), which the bindings now surface as a
+    # ValueError instead of a generic RuntimeError. See #413.
     bm1 = BoundedMean(1, 0, 1, 10)
     bm1.add_entries([1 for i in range(100)])
     bm1.result()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         bm1.result()
 
 

--- a/tests/algorithms/test_error_types.py
+++ b/tests/algorithms/test_error_types.py
@@ -1,0 +1,50 @@
+# third party
+import pytest
+
+# pydp absolute
+import pydp._pydp as dp
+import pydp.algorithms.laplacian as py_algos
+
+# Regression tests for #413: the bindings used to collapse every non-OK
+# absl::Status coming back from the DP library into a plain RuntimeError,
+# no matter what actually went wrong. That made it impossible to tell "you
+# passed a bad argument" apart from "something failed internally" without
+# parsing the exception message. These tests pin down the exception types
+# for the status codes that are easy to trigger deterministically from
+# Python: InvalidArgument (now ValueError) and Internal (still RuntimeError,
+# since there's no better built-in fit).
+
+
+def test_double_result_raises_value_error_not_runtime_error():
+    # The DP library refuses to hand out a result twice for the same
+    # epsilon/delta budget and returns an InvalidArgument status for the
+    # second call. That should surface as a ValueError.
+    count = py_algos.Count(epsilon=1.0)
+    count.add_entries([1] * 10)
+
+    count.result()
+    with pytest.raises(ValueError):
+        count.result()
+
+
+def test_double_result_error_is_not_a_bare_runtime_error():
+    # Guard against a ValueError subclassing RuntimeError one day and this
+    # test passing for the wrong reason.
+    count = py_algos.Count(epsilon=1.0)
+    count.add_entries([1] * 10)
+    count.result()
+
+    with pytest.raises(ValueError) as exc_info:
+        count.result()
+    assert not isinstance(exc_info.value, RuntimeError)
+
+
+def test_merge_empty_summary_still_raises_runtime_error():
+    # Merging an empty Summary trips an Internal status in the DP library
+    # (there's no count data to merge). Internal errors don't have an
+    # obviously-better built-in Python exception, so they should keep
+    # raising RuntimeError, same as before this change.
+    count = py_algos.Count(epsilon=1.0)
+
+    with pytest.raises(RuntimeError):
+        count.merge(dp.Summary())


### PR DESCRIPTION
Every result/build/merge call in `algorithm_builder.hpp` catches a non-OK `absl::Status` from the C++ DP library and turns it into `std::runtime_error`, which pybind11 maps to a plain Python `RuntimeError`. That's the same exception type whether you passed in a bad epsilon, asked for a result you'd already consumed, or hit a genuine internal failure in the library. From Python there's no way to `except` your way out of the cases that are actually your fault versus the ones that aren't, short of parsing the message string.

## What I did

I traced through the vendored `differential-privacy` source at the pinned submodule commit to see what status codes these specific call sites (`build`, `result`, `partial_result` x3, `merge`) can actually produce. The two I could pin down cleanly:

- `kInvalidArgument` - by far the most common. Covers things like bad bounds/overflow in the builder, and (somewhat non-obviously) calling `result()`/`partial_result()` a second time on the same algorithm instance, since `Algorithm::PartialResult()` in `algorithm.h` explicitly returns `InvalidArgumentError` once `result_returned_` is already true.
- `kUnimplemented` - returned by the base `NoiseConfidenceInterval()` for algorithms that don't override it.
- `kInternal` - e.g. `Count::Merge()` on an empty `Summary`.

```mermaid
flowchart LR
    A[absl::Status from DP library] --> B{status.code}
    B -- kInvalidArgument --> C[py::value_error → ValueError]
    B -- kUnimplemented --> D[PyErr_SetString NotImplementedError]
    B -- everything else --> E[std::runtime_error → RuntimeError]
```

I added a small `ThrowFromStatus()` helper in a new `status_errors.hpp` and swapped it in at all six throw sites in `algorithm_builder.hpp`. `kInvalidArgument` maps to `ValueError` using pybind11's built-in `py::value_error` (already the pattern used for build errors in `qunatile_tree.cpp`, so this isn't introducing a new convention). `kUnimplemented` maps to `NotImplementedError` via `PyErr_SetString`, since pybind11 doesn't ship a wrapper for that one. Everything else - `kInternal`, `kFailedPrecondition`, anything I didn't verify - still raises `RuntimeError`, same as before. I didn't want to guess at mappings for codes I hadn't actually traced back to a real code path.

One existing test, `test_bounded_mean.py::test_result_crash`, asserted `RuntimeError` for the "call result() twice" case - that's actually the `InvalidArgument` path, so I updated it to expect `ValueError` and left a comment explaining why. I also added `tests/algorithms/test_error_types.py` with a couple of focused regression tests: one confirms the double-result case now raises `ValueError` (and explicitly isn't just accidentally a `RuntimeError` subclass), and another confirms merging an empty `Summary` still raises `RuntimeError`, so the change doesn't accidentally widen beyond what I verified.

## Testing

This one's a C++ binding change, and I wasn't able to build the extension locally to run these against the real bindings - the CI workflow itself budgets 20 minutes just for the Google DP library build step, which is more than makes sense for a local sanity-check loop in this environment. What I did do:

- Read the exact status-returning code paths in the pinned `differential-privacy` submodule commit for every scenario the new tests exercise, rather than guessing.
- Ran `black --check` and `clang-format --style=file` (matching `.clang-format`, which is what this repo's CI uses) against every file I touched - all clean, no diffs.
- `py_compile` on the Python test files.

I'm relying on CI here to actually build and run the test suite - opening this as a draft until that comes back green, at which point I'll flip it to ready for review.

Fixes #413
